### PR TITLE
Support old tokens that don't include `role` key

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -205,7 +205,9 @@ def create_user(encoded_token):
         )
         abort(400, INVALID_TOKEN_MESSAGE)
 
-    role = token["role"]
+    # This logic is to support old tokens (that don't include a 'role' key). After 7 days of the user-frontend being
+    # live we can drop it and just get the role from the token.
+    role = token.get('role') or 'supplier' if token.get('supplier_id') else 'buyer'
 
     if token.get('error') == 'token_expired':
         current_app.logger.warning(

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -761,6 +761,56 @@ class TestCreateUser(BaseApplicationTest):
         assert u"You were invited by ‘Different Supplier Name’" in res.get_data(as_text=True)
         assert u"Your account is registered with ‘Supplier Name’" in res.get_data(as_text=True)
 
+    @mock.patch('app.main.views.auth.data_api_client')
+    def test_should_work_for_old_buyer_token_without_role(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        token = generate_token(
+            {'email_address': 'test@example.com'},
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['INVITE_EMAIL_SALT']
+        )
+
+        res = self.client.get(
+            '/user/create/{}'.format(token)
+        )
+        assert res.status_code == 200
+
+        for message in [
+            "Create a new Digital Marketplace account",
+            "Create account",
+            "test@example.com",
+            '<form autocomplete="off" action="/user/create/%s" method="POST" id="createUserForm">'
+                % urllib.parse.quote(token)
+        ]:
+            assert message in res.get_data(as_text=True)
+
+    @mock.patch('app.main.views.auth.data_api_client')
+    def test_should_work_for_old_supplier_token_without_role(self, data_api_client):
+        data_api_client.get_user.return_value = None
+        token = generate_token(
+            {
+                "supplier_id": '12345',
+                "supplier_name": 'Supplier Name',
+                "email_address": 'test@example.com'
+            },
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['INVITE_EMAIL_SALT']
+        )
+
+        res = self.client.get(
+            '/user/create/{}'.format(token)
+        )
+        assert res.status_code == 200
+
+        for message in [
+            'Create contributor account',
+            'Create contributor account',
+            "test@example.com",
+            '<form autocomplete="off" action="/user/create/%s" method="POST" id="createUserForm">'
+                % urllib.parse.quote(token)
+        ]:
+            assert message in res.get_data(as_text=True)
+
 
 class TestSubmitCreateUser(BaseApplicationTest):
 


### PR DESCRIPTION
Tokens have a lifespan of seven days. The new tokens include a `role`
key. We need to support the old style tokens until they are all no
longer valid.