### PR TITLE
Support old tokens

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.0.1#egg=digitalmarketplace-utils==28.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.0.2#egg=digitalmarketplace-utils==28.0.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.0.1#egg=digitalmarketplace-utils==28.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.0.2#egg=digitalmarketplace-utils==28.0.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1
 


### PR DESCRIPTION
This PR will need merging first: [https://github.com/alphagov/digitalmarketplace-utils/pull/324](https://github.com/alphagov/digitalmarketplace-utils/pull/324)

Tokens have a lifespan of seven days. The new tokens include a `role`
key. We need to support the old style tokens until they are all no
longer valid.