### PR TITLE
Add a check for safe url for redirects after login

### DIFF
--- a/app/main/helpers/login_helpers.py
+++ b/app/main/helpers/login_helpers.py
@@ -1,20 +1,32 @@
+from urllib.parse import urlparse, urljoin
+
 from flask_login import current_user
-from flask import redirect, url_for
+from flask import request, redirect, url_for
+
+
+def is_safe_url(next_url):
+    """
+    Return `True` if the url is safe to use in a redirect (ie it doesn't point to
+    an external host or change the scheme from http[s]).
+
+    Returns `False` if url is empty.
+
+    """
+    if not next_url:
+        return False
+
+    app_host = urlparse(request.host_url).netloc
+    next_url = urlparse(urljoin(request.host_url, next_url))
+
+    return next_url.scheme in ['http', 'https'] and next_url.netloc == app_host
 
 
 def redirect_logged_in_user(next_url=None):
-    if current_user.is_authenticated():
-        if current_user.role == 'supplier':
-            if next_url and next_url.startswith('/suppliers'):
-                return redirect(next_url)
-            else:
-                return redirect('/suppliers')
-        if current_user.role.startswith('admin'):
-            if next_url and next_url.startswith('/admin'):
-                return redirect(next_url)
-            else:
-                return redirect('/admin')
-        if next_url and next_url.startswith('/'):
-            return redirect(next_url)
-
-    return redirect(url_for('external.index'))
+    if is_safe_url(next_url):
+        return redirect(next_url)
+    elif current_user.role == 'supplier':
+        return redirect('/suppliers')
+    elif current_user.role.startswith('admin'):
+        return redirect('/admin')
+    else:
+        return redirect(url_for('external.index'))

--- a/tests/main/helpers/test_login_helpers.py
+++ b/tests/main/helpers/test_login_helpers.py
@@ -1,0 +1,62 @@
+import mock
+import pytest
+
+from collections import namedtuple
+
+from app.main.helpers.login_helpers import is_safe_url
+
+
+@pytest.fixture()
+def host_url(request):
+    fake_request = namedtuple('Request', ['host_url'])('http://localhost/')
+    request_patch = mock.patch('app.main.helpers.login_helpers.request', fake_request)
+    request.addfinalizer(request_patch.stop)
+
+    return request_patch.start()
+
+
+@pytest.fixture(params=['buyer', 'supplier', 'admin', 'admin-ccs-category'])
+def current_user(request):
+    fake_user = namedtuple('User', ['role'])(request.param)
+    request_patch = mock.patch('app.main.helpers.login_helpers.current_user', fake_user)
+    request.addfinalizer(request_patch.stop)
+
+    return request_patch.start()
+
+
+@pytest.mark.parametrize('next_url', [None, ''])
+def test_empty_next_url_is_not_safe(host_url, next_url):
+    assert not is_safe_url(next_url)
+
+
+@pytest.mark.parametrize('next_url', [
+    'https://example.com/suppliers',
+    'http://localhost:5000/',
+    'http://example.com/',
+    '//example.com/',
+])
+def test_external_host_url_is_not_safe(host_url, next_url):
+    assert not is_safe_url(next_url)
+
+
+@pytest.mark.parametrize('next_url', [
+    'file://example.pdf',
+    'file:example.pdf',
+    'mailto:user@example.com',
+    'javascript:alert(1);',
+    'about:blank',
+    'git://localhost/',
+])
+def test_non_http_scheme_is_not_safe(host_url, next_url):
+    assert not is_safe_url(next_url)
+
+
+@pytest.mark.parametrize('next_url', [
+    'http://localhost/suppliers'
+    '/suppliers',
+    'logout',
+    '/admin',
+    '../../',
+])
+def test_same_origin_url_is_safe(host_url, next_url):
+    assert is_safe_url(next_url)

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -84,6 +84,12 @@ class TestLogin(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == 'http://localhost/admin'
 
+    def test_should_redirect_to_next_url_for_simple_auth_uri(self):
+        self.login_as_supplier()
+        res = self.client.get("/user/login?next=@example.com")
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/@example.com'
+
     def test_should_redirect_logged_in_admin_to_next_url_if_admin_app(self):
         self.login_as_admin()
         res = self.client.get("/user/login?next=/admin/foo-bar")

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -72,6 +72,18 @@ class TestLogin(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == 'http://localhost/admin'
 
+    def test_should_redirect_to_dashboard_if_next_url_is_unsafe(self):
+        self.login_as_supplier()
+        res = self.client.get("/user/login?next=//example.com")
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/suppliers'
+
+    def test_should_redirect_to_dashboard_if_next_url_is_not_http(self):
+        self.login_as_admin()
+        res = self.client.get("/user/login?next=file:example.pdf")
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/admin'
+
     def test_should_redirect_logged_in_admin_to_next_url_if_admin_app(self):
         self.login_as_admin()
         res = self.client.get("/user/login?next=/admin/foo-bar")
@@ -83,12 +95,6 @@ class TestLogin(BaseApplicationTest):
         res = self.client.get("/user/login?next=/suppliers/foo-bar")
         assert res.status_code == 302
         assert res.location == 'http://localhost/suppliers/foo-bar'
-
-    def test_should_redirect_to_supplier_dashboard_if_next_url_not_supplier_app(self):
-        self.login_as_supplier()
-        res = self.client.get("/user/login?next=/foo-bar")
-        assert res.status_code == 302
-        assert res.location == 'http://localhost/suppliers'
 
     def test_should_strip_whitespace_surrounding_login_email_address_field(self):
         self.client.post("/user/login", data={

--- a/tests/main/views/test_create_user.py
+++ b/tests/main/views/test_create_user.py
@@ -579,6 +579,14 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
     @mock.patch('app.main.views.create_user.data_api_client')
     def test_should_create_buyer_user_if_no_phone_number(self, data_api_client):
+        data_api_client.create_user.return_value = {
+            "users": {
+                "id": "1234",
+                "emailAddress": "test@email.com",
+                "name": "valid name",
+                "role": "buyer",
+            }
+        }
 
         token = self._generate_token(role='buyer')
         res = self.client.post(
@@ -618,6 +626,14 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
     @mock.patch('app.main.views.create_user.data_api_client')
     def test_should_strip_whitespace_surrounding_create_user_name_field(self, data_api_client):
+        data_api_client.create_user.return_value = {
+            "users": {
+                "id": "1234",
+                "emailAddress": "test@email.com",
+                "name": "valid name",
+                "role": "buyer",
+            }
+        }
         data_api_client.get_user.return_value = None
         token = self._generate_token(role='buyer')
         self.client.post(
@@ -639,7 +655,14 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
     @mock.patch('app.main.views.create_user.data_api_client')
     def test_should_not_strip_whitespace_surrounding_create_user_password_field(self, data_api_client):
-        data_api_client.get_user.return_value = None
+        data_api_client.create_user.return_value = {
+            "users": {
+                "id": "1234",
+                "emailAddress": "test@email.com",
+                "name": "valid name",
+                "role": "buyer",
+            }
+        }
         token = self._generate_token(role='buyer')
         self.client.post(
             '/user/create/{}'.format(token),


### PR DESCRIPTION
After the buyer users have been added to the list of roles the prefix
checks no longer restrict protocol-relative URLs (eg //example.com),
allowing the login page to redirect the user to an external domain.

This is adding a `is_safe_url` function based on the one from
http://flask.pocoo.org/snippets/62/ (it's also used by Notify).

The function is modified to return `False` for empty target URLs.

This also removes per-role redirect restrictions since their original
purpose was to prevent the open redirects. User role now only affects
the default redirect location if next_url was not set, otherwise
next_url is used as is.