### PR TITLE
Update message content for failed login and password reset

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -13,8 +13,8 @@ from ... import data_api_client
 
 
 NO_ACCOUNT_MESSAGE = Markup("""Make sure you've entered the right email address and password. Accounts
-    are locked after 5 failed attempts. If you think your account has been locked, email
-    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.""")
+    are locked after 5 failed attempts. If you’ve forgotten your password you can reset it by clicking
+    ‘Forgotten password’.""")
 
 
 @main.route('/login', methods=["GET"])

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -12,8 +12,9 @@ from ... import data_api_client
 
 
 EMAIL_SENT_MESSAGE = Markup(
-    """If the email address you've entered belongs to a Digital Marketplace account,
-    we'll send a link to reset the password.
+    """If the email address you've entered belongs to a Digital Marketplace account, we'll send a link to reset the
+    password. If you don’t receive this, email
+    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
     """
 )
 


### PR DESCRIPTION
Part of this trello ticket: https://trello.com/c/HlSz9QZZ

Users who have locked their account can now reset it via the forgotten
password process. This means they no longer need to involve support.

These updated messages will encourage them to use this process and only
contact support if that doesn't work.

#### Failed login message
<img width="1440" alt="screen shot 2017-09-21 at 14 49 59" src="https://user-images.githubusercontent.com/13836290/30699498-d0aa48e6-9edc-11e7-833e-1c7ad5d7f6a3.png">

#### Reset password email message
<img width="1440" alt="screen shot 2017-09-21 at 14 54 12" src="https://user-images.githubusercontent.com/13836290/30699507-d8956a9a-9edc-11e7-83c5-e3e781985618.png">
