### PR TITLE
Remove legacy pep8 entry from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
-[pep8]
-exclude = ./venv*,./bower_components,./node_modules,./app/content
-max-line-length = 120
-
 [pytest]
 norecursedirs = venv* app/content bower_components node_modules


### PR DESCRIPTION
`grep -RiIn --exclude=*bower* --exclude=*venv* --exclude=*.css --exclude=*.git* 'pep8' .`

Showed only the `setup.cfg`