### PR TITLE
Add milliseconds to application log time format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:2.0.4
+FROM digitalmarketplace/base-frontend:2.0.5

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.2.1#egg=digitalmarketplace-utils==28.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,16 +6,16 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.2.1#egg=digitalmarketplace-utils==28.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.22.0
+asn1crypto==0.23.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-cffi==1.10.0
+cffi==1.11.2
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
@@ -34,6 +34,7 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.3
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1


### PR DESCRIPTION
Upgrades dmutils and base Docker image to add milliseconds to app logs shipped to CloudWatch.

This allows us to maintain the order of the log messages written by an application instance in Kibana.