### PR TITLE
Pull in latest utils

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@30.0.0#egg=digitalmarketplace-utils==30.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@30.0.0#egg=digitalmarketplace-utils==30.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1
 

--- a/tests/main/views/test_create_user.py
+++ b/tests/main/views/test_create_user.py
@@ -243,56 +243,6 @@ class TestCreateUser(BaseApplicationTest):
         assert u"You were invited by ‘Different Supplier Name’" in res.get_data(as_text=True)
         assert u"Your account is registered with ‘Supplier Name’" in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_work_for_old_buyer_token_without_role(self, data_api_client):
-        data_api_client.get_user.return_value = None
-        token = generate_token(
-            {'email_address': 'test@example.com'},
-            self.app.config['SHARED_EMAIL_KEY'],
-            self.app.config['INVITE_EMAIL_SALT']
-        )
-
-        res = self.client.get(
-            '/user/create/{}'.format(token)
-        )
-        assert res.status_code == 200
-
-        for message in [
-            "Create a new Digital Marketplace account",
-            "Create account",
-            "test@example.com",
-            '<form autocomplete="off" action="/user/create/%s" method="POST" id="createUserForm">'
-                % urllib.parse.quote(token)
-        ]:
-            assert message in res.get_data(as_text=True)
-
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_work_for_old_supplier_token_without_role(self, data_api_client):
-        data_api_client.get_user.return_value = None
-        token = generate_token(
-            {
-                "supplier_id": '12345',
-                "supplier_name": 'Supplier Name',
-                "email_address": 'test@example.com'
-            },
-            self.app.config['SHARED_EMAIL_KEY'],
-            self.app.config['INVITE_EMAIL_SALT']
-        )
-
-        res = self.client.get(
-            '/user/create/{}'.format(token)
-        )
-        assert res.status_code == 200
-
-        for message in [
-            'Add your name and create a password',
-            'Create account',
-            "test@example.com",
-            '<form autocomplete="off" action="/user/create/%s" method="POST" id="createUserForm">'
-                % urllib.parse.quote(token)
-        ]:
-            assert message in res.get_data(as_text=True)
-
     def test_should_render_correct_error_page_for_old_style_expired_buyer_token(self):
         for role in self.user_roles:
             with freeze_time('2016-09-28 16:00:00'):


### PR DESCRIPTION
The latest version of utils removes a bit of code that deals with the case where tokens don't have a user role. The new way of generating tokens should have made that code obsolete, so this PR *shouldn't* break anything.