### PR TITLE
Change from flake8-putty to flake8-per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,8 @@ exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 7
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
-    app/main/views/*.py : +C901
+per-file-ignores =
+    **/__init__.py : F401
+    app/main/__init__.py : E402
+    app/status/__init__.py : E402
+    app/main/views/*.py : C901

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 
 #Required for testing
 pytest==3.2.3
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 mock==2.0.0
 lxml==3.8.0
 cssselect==0.9.1


### PR DESCRIPTION
This allows us to use newer Python3 syntax including f-strings and type annotations.


```
samuelwilliams:~/git/digitalmarketplace-user-frontend [master]$ make test-flake8
[ -z $VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
/Users/samuelwilliams/git/digitalmarketplace-user-frontend/venv/bin/flake8 .
./app/__init__.py:0:1: X100 Superfluous per-file-ignores for E402
make: *** [test-flake8] Error 1
```