### PR TITLE
Use `SHARED_EMAIL_KEY` to encrypt reset password email tokens

### DIFF
--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -49,7 +49,7 @@ def send_reset_password_email():
                 {
                     "user": user.id
                 },
-                current_app.config['SECRET_KEY'],
+                current_app.config['SHARED_EMAIL_KEY'],
                 current_app.config['RESET_PASSWORD_SALT']
             )
 

--- a/config.py
+++ b/config.py
@@ -74,7 +74,7 @@ class Test(Config):
 
     DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
     SHARED_EMAIL_KEY = "KEY"
-    SECRET_KEY = "KEY"
+    SECRET_KEY = "KEY2"
 
 
 class Development(Config):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.2.0#egg=digitalmarketplace-utils==31.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.4.0#egg=digitalmarketplace-utils==31.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,6 @@ s3transfer==0.1.12
 six==1.9.0
 unicodecsv==0.14.1
 urllib3==1.22
-Werkzeug==0.12.2
+Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,17 +6,18 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@31.2.0#egg=digitalmarketplace-utils==31.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@31.4.0#egg=digitalmarketplace-utils==31.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.23.0
+asn1crypto==0.24.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-certifi==2017.11.5
-cffi==1.11.2
+certifi==2018.1.18
+cffi==1.11.4
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -36,7 +37,6 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
-odfpy==1.3.3
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -256,7 +256,7 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
                     "user": 123,
                     "email": 'email@email.com',
                 },
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
 
             url = '/user/reset-password/{}'.format(token)

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -167,10 +167,13 @@ class TestLogin(BaseApplicationTest):
                 'email_address': 'valid@email.com',
                 'password': '1234567890'
             })
+
+            properties = ['Secure', 'HttpOnly', 'Domain=127.0.0.1', 'Path=/']
+            for prop in properties:
+                assert prop in res.headers['Set-Cookie']
+
             cookie_value = self.get_cookie_by_name(res, 'dm_session')
             assert cookie_value['dm_session'] is not None
-            assert cookie_value['Secure; HttpOnly; Path'] == '/'
-            assert cookie_value["Domain"] == "127.0.0.1"
 
     def test_should_redirect_to_login_on_logout(self):
         res = self.client.post('/user/logout')

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -84,7 +84,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -96,7 +96,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -112,7 +112,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -127,7 +127,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -144,7 +144,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -159,7 +159,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -178,7 +178,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -197,7 +197,7 @@ class TestResetPassword(BaseApplicationTest):
         with self.app.app_context():
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 
@@ -218,7 +218,7 @@ class TestResetPassword(BaseApplicationTest):
             )
             token = generate_token(
                 self._user,
-                self.app.config['SECRET_KEY'],
+                self.app.config['SHARED_EMAIL_KEY'],
                 self.app.config['RESET_PASSWORD_SALT'])
             url = '/user/reset-password/{}'.format(token)
 


### PR DESCRIPTION
https://trello.com/c/WTbemGdn/219-reset-password-emails-are-using-secretkey-instead-of-sharedemailkey-to-encrypt-tokens

Note, tests will likely fail until utils PR - https://github.com/alphagov/digitalmarketplace-utils/pull/354 - is merged and then pulled into this pull request.

We will be changing our tokens for reset password emails to be
generated using the `SHARED_EMAIL_KEY` rather than the `SECRET_KEY`.
This is because
- this will be consistent with the other email tokens we generate
- although there is technically no harm in using `SECRET_KEY`,
the actual purpose of the `SECRET_KEY` is to be used for encrypting
Flask sessions. This would mean if we needed to rotate a key for
our Flask sessions it would also break out email tokens and vice
versa. By using different keys we should reduce the risk of a
token rotation having an impact on too large a part of the site

Note, the new version of utils brought in will mean that we still
succesfully decrypt and allow tokens that were previously
generated using the old `SECRET_KEY`. After 1 full day of support,
they would all become invalid anyway so after that point we can
also remove support for allowing old `SECRET_KEY` tokens.