### PR TITLE
Revert back to eea/odfpy

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,9 @@ def create_app(config_name):
     from .main import main as main_blueprint
 
     application.register_blueprint(main_blueprint, url_prefix='/user')
+
+    # Must be registered last so that any routes declared in the app are registered first (i.e. take precedence over
+    # the external NotImplemented routes in the dm-utils external blueprint).
     application.register_blueprint(external_blueprint)
 
     login_manager.login_view = 'main.render_login'

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@32.0.0#egg=digitalmarketplace-utils==32.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,9 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@32.0.0#egg=digitalmarketplace-utils==32.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.0#egg=digitalmarketplace-utils==33.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
@@ -37,6 +36,7 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.5.3
 python-dateutil==2.6.1


### PR DESCRIPTION
Update utils to use eea/odfpy rather than our interim alphagov/odfpy
fork, which we created to allow us to patch a bug. Now that the bug has
been accepted into the main library as of release 1.3.6
(https://github.com/eea/odfpy/pull/72) we no longer need to support
own our fork.

Also adds a comment when registering the external blueprint from 
dm-utils to ensure it is registered last.