### PR TITLE
Bump dockerfile to 3.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:3.1.1
+FROM digitalmarketplace/base-frontend:3.1.2


### PR DESCRIPTION
Updates the base image for deployed containers to 3.1.2 which uses absolute paths for all executables in buildsteps