### PR TITLE
Clear session variables on logout

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -1,6 +1,16 @@
 # coding: utf-8
 from flask_login import current_user
-from flask import current_app, flash, redirect, render_template, request, url_for, get_flashed_messages, Markup
+from flask import (
+    current_app,
+    flash,
+    get_flashed_messages,
+    Markup,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for
+)
 from flask_login import logout_user, login_user
 
 from dmutils.user import User
@@ -62,5 +72,6 @@ def process_login():
 
 @main.route('/logout', methods=["POST"])
 def logout():
+    session.clear()
     logout_user()
     return redirect(url_for('.render_login'))

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -180,6 +180,16 @@ class TestLogin(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == 'http://localhost/user/login'
 
+    def test_should_expire_session_vars_on_logout(self):
+        self.login_as_supplier()
+        with self.client.session_transaction() as session:
+            session['company_name'] = "Acme Corp"
+
+        self.client.post('/user/logout')
+
+        with self.client.session_transaction() as session:
+            assert session.get('company_name') is None
+
     @mock.patch('app.main.views.auth.data_api_client')
     def test_should_return_a_403_for_invalid_login(self, data_api_client):
         data_api_client.authenticate_user.return_value = None


### PR DESCRIPTION
Flask's `logout_user` does not clear all session variables: https://flask-login.readthedocs.io/en/latest/_modules/flask_login/utils.html#logout_user

This PR explicitly clears any session variables (e.g. set during supplier applications) immediately prior to logout.