### PR TITLE
request id handling: bump digitalmarketplace-utils dependency to 34.1.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@33.0.1#egg=digitalmarketplace-utils==33.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@13.1.0#egg=digitalmarketplace-apiclient==13.1.0
 
@@ -16,7 +16,7 @@ backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
 certifi==2018.1.18
-cffi==1.11.4
+cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
@@ -38,13 +38,13 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.5.3
+PyJWT==1.6.0
 python-dateutil==2.6.1
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
-s3transfer==0.1.12
+s3transfer==0.1.13
 six==1.9.0
 unicodecsv==0.14.1
 urllib3==1.22


### PR DESCRIPTION
...and re-freeze requirements.txt. this should bring in the new request id header handling.

https://trello.com/c/dlbLmRDB/343-make-use-of-zipkin-headers-in-preference-to-request-id-pt-1