### PR TITLE
notify example redirection: switch the target email addresses to SES's equivalent simulated addresses

### DIFF
--- a/config.py
+++ b/config.py
@@ -98,8 +98,8 @@ class Live(Config):
 
     # use of invalid email addresses with live api keys annoys Notify
     DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = {
-        "example.com": "simulate-delivered@notifications.service.gov.uk",
-        "example.gov.uk": "simulate-delivered-2@notifications.service.gov.uk",
+        "example.com": "success@simulator.amazonses.com",
+        "example.gov.uk": "success@simulator.amazonses.com",
     }
 
 


### PR DESCRIPTION
This should work fine as long as notify is using SES as their backend. if they change this, we just have to change this setting. using this has the advantage that it will appear to be "delivered" as far as notify's concerned and a record of the message's reference id will be kept.