### PR TITLE
414 inadequate session termination

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,10 +7,9 @@
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules
 ignore = D203,W503
-max-complexity = 7
+max-complexity = 9
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401
     app/main/__init__.py : E402
     app/status/__init__.py : E402
-    app/main/views/*.py : C901

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -75,6 +75,13 @@ def create_app(config_name):
         session.permanent = True
         session.modified = True
 
+    @application.after_request
+    def remove_invalid_session_cookie(response):
+        # auth.logout sets __invalidate__ flag in session
+        if "__invalidate__" in session:
+            response.set_cookie(application.session_cookie_name, '', expires=0)
+        return response
+
     return application
 
 

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -73,5 +73,6 @@ def process_login():
 @main.route('/logout', methods=["POST"])
 def logout():
     session.clear()
+    session['__invalidate__'] = True
     logout_user()
     return redirect(url_for('.render_login'))

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -190,6 +190,21 @@ class TestLogin(BaseApplicationTest):
         with self.client.session_transaction() as session:
             assert session.get('company_name') is None
 
+    def test_should_remove_session_cookie_on_logout(self):
+        with self.app.app_context():
+            res = self.client.post("/login", data={
+                'email_address': 'valid@email.com',
+                'password': '1234567890'
+            })
+
+            cookie_value_1 = self.get_cookie_by_name(res, 'dm_session')
+            assert cookie_value_1['dm_session'] is not None
+
+            res2 = self.client.post('/user/logout')
+
+            cookie_value_2 = self.get_cookie_by_name(res2, 'dm_session')
+            assert cookie_value_2['dm_session'] == ''
+
     @mock.patch('app.main.views.auth.data_api_client')
     def test_should_return_a_403_for_invalid_login(self, data_api_client):
         data_api_client.authenticate_user.return_value = None


### PR DESCRIPTION
Trello https://trello.com/c/NStzgIbd/414-inadequate-session-termination

The recent pen test highlighted that our sessions are not invalidated properly on logout. 

This possible solution sets the session cookie's expiry to the Unix epoch (which one would hope is in the past). 

I'm not 100% sure this will be sufficient! It's also hard to test in-browser as a new session cookie is immediately set for the logged out user. 

Thoughts/alternative suggestions welcome.