### PR TITLE
Refactor User FE tests

### DIFF
--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -44,15 +44,14 @@ class TestLogin(BaseApplicationTest):
 
     @mock.patch('app.main.views.auth.data_api_client')
     def test_should_redirect_to_homepage_on_buyer_login(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
-            res = self.client.post("/user/login", data={
-                'email_address': 'valid@email.com',
-                'password': '1234567890'
-            })
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/'
-            assert 'Secure;' in res.headers['Set-Cookie']
+        data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
+        res = self.client.post("/user/login", data={
+            'email_address': 'valid@email.com',
+            'password': '1234567890'
+        })
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/'
+        assert 'Secure;' in res.headers['Set-Cookie']
 
     def test_should_redirect_logged_in_supplier_to_supplier_dashboard(self):
         self.login_as_supplier()
@@ -128,15 +127,14 @@ class TestLogin(BaseApplicationTest):
 
     @mock.patch('app.main.views.auth.data_api_client')
     def test_ok_next_url_redirects_buyer_on_login(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
-            res = self.client.post("/user/login?next=/bar-foo",
-                                   data={
-                                       'email_address': 'valid@email.com',
-                                       'password': '1234567890'
-                                   })
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/bar-foo'
+        data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
+        res = self.client.post("/user/login?next=/bar-foo",
+                               data={
+                                   'email_address': 'valid@email.com',
+                                   'password': '1234567890'
+                               })
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/bar-foo'
 
     def test_bad_next_url_takes_supplier_user_to_dashboard(self):
         res = self.client.post("/user/login?next=http://badness.com",
@@ -149,31 +147,29 @@ class TestLogin(BaseApplicationTest):
 
     @mock.patch('app.main.views.auth.data_api_client')
     def test_bad_next_url_takes_buyer_user_to_homepage(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
-            res = self.client.post("/user/login?next=http://badness.com",
-                                   data={
-                                       'email_address': 'valid@email.com',
-                                       'password': '1234567890'
-                                   })
+        data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
+        res = self.client.post("/user/login?next=http://badness.com",
+                               data={
+                                   'email_address': 'valid@email.com',
+                                   'password': '1234567890'
+                               })
         assert res.status_code == 302
         assert res.location == 'http://localhost/'
 
     def test_should_have_cookie_on_redirect(self):
-        with self.app.app_context():
-            self.app.config['SESSION_COOKIE_DOMAIN'] = '127.0.0.1'
-            self.app.config['SESSION_COOKIE_SECURE'] = True
-            res = self.client.post("/login", data={
-                'email_address': 'valid@email.com',
-                'password': '1234567890'
-            })
+        self.app.config['SESSION_COOKIE_DOMAIN'] = '127.0.0.1'
+        self.app.config['SESSION_COOKIE_SECURE'] = True
+        res = self.client.post("/login", data={
+            'email_address': 'valid@email.com',
+            'password': '1234567890'
+        })
 
-            properties = ['Secure', 'HttpOnly', 'Domain=127.0.0.1', 'Path=/']
-            for prop in properties:
-                assert prop in res.headers['Set-Cookie']
+        properties = ['Secure', 'HttpOnly', 'Domain=127.0.0.1', 'Path=/']
+        for prop in properties:
+            assert prop in res.headers['Set-Cookie']
 
-            cookie_value = self.get_cookie_by_name(res, 'dm_session')
-            assert cookie_value['dm_session'] is not None
+        cookie_value = self.get_cookie_by_name(res, 'dm_session')
+        assert cookie_value['dm_session'] is not None
 
     def test_should_redirect_to_login_on_logout(self):
         res = self.client.post('/user/logout')
@@ -262,17 +258,15 @@ class TestLoginFormsNotAutofillable(BaseApplicationTest):
         data_api_client.get_user.return_value = self.user(
             123, "email@email.com", 1234, 'email', 'name'
         )
+        token = generate_token(
+            {
+                "user": 123,
+                "email": 'email@email.com',
+            },
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
 
-        with self.app.app_context():
-            token = generate_token(
-                {
-                    "user": 123,
-                    "email": 'email@email.com',
-                },
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-
-            url = '/user/reset-password/{}'.format(token)
+        url = '/user/reset-password/{}'.format(token)
 
         self._forms_and_inputs_not_autofillable(
             url,

--- a/tests/main/views/test_create_user.py
+++ b/tests/main/views/test_create_user.py
@@ -389,26 +389,25 @@ class TestSubmitCreateUser(BaseApplicationTest):
             "Add your name and create a password"
         ]
         for role, page_heading in zip(self.user_roles, page_headings):
-            with self.app.app_context():
-                token = self._generate_token(role=role)
-                twofiftysix = "a" * 256
-                fiftyone = "a" * 51
+            token = self._generate_token(role=role)
+            twofiftysix = "a" * 256
+            fiftyone = "a" * 51
 
-                res = self.client.post(
-                    '/user/create/{}'.format(token),
-                    data={
-                        'password': fiftyone,
-                        'name': twofiftysix
-                    }
-                )
-                assert res.status_code == 400
-                for message in [
-                    page_heading,
-                    "Names must be between 1 and 255 characters",
-                    "Passwords must be between 10 and 50 characters",
-                    "test@email.com"
-                ]:
-                    assert message in res.get_data(as_text=True)
+            res = self.client.post(
+                '/user/create/{}'.format(token),
+                data={
+                    'password': fiftyone,
+                    'name': twofiftysix
+                }
+            )
+            assert res.status_code == 400
+            for message in [
+                page_heading,
+                "Names must be between 1 and 255 characters",
+                "Passwords must be between 10 and 50 characters",
+                "test@email.com"
+            ]:
+                assert message in res.get_data(as_text=True)
 
     @mock.patch('app.main.views.create_user.data_api_client')
     def test_should_create_buyer_user_if_user_does_not_exist(self, data_api_client):
@@ -634,18 +633,17 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
     @mock.patch('app.main.views.create_user.data_api_client')
     def test_should_be_a_503_if_api_fails(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.create_user.side_effect = HTTPError("bad email")
+        data_api_client.create_user.side_effect = HTTPError("bad email")
 
-            token = self._generate_token(role='buyer')
-            res = self.client.post(
-                '/user/create/{}'.format(token),
-                data={
-                    'password': 'validpassword',
-                    'name': 'valid name'
-                }
-            )
-            assert res.status_code == 503
+        token = self._generate_token(role='buyer')
+        res = self.client.post(
+            '/user/create/{}'.format(token),
+            data={
+                'password': 'validpassword',
+                'name': 'valid name'
+            }
+        )
+        assert res.status_code == 503
 
     @mock.patch('app.main.views.create_user.data_api_client')
     def test_should_render_error_page_if_invalid_buyer_domain(self, data_api_client):

--- a/tests/main/views/test_create_user.py
+++ b/tests/main/views/test_create_user.py
@@ -14,6 +14,15 @@ from app.main.views.create_user import INVALID_TOKEN_MESSAGE
 
 class TestCreateUser(BaseApplicationTest):
 
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.create_user.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
+
     user_roles = ['buyer', 'supplier']
 
     def _generate_token(self, email_address='test@email.com', role='buyer',
@@ -58,8 +67,7 @@ class TestCreateUser(BaseApplicationTest):
             assert res.status_code == 400
             assert INVALID_TOKEN_MESSAGE in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_invalid_token_contents_500s(self, data_api_client):
+    def test_invalid_token_contents_500s(self):
         token = generate_token(
             {
                 'this_is_not_expected': 1234
@@ -90,9 +98,8 @@ class TestCreateUser(BaseApplicationTest):
             assert 'The link you used to create an account may have expired.' in res.get_data(as_text=True)
             assert message in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_render_create_user_page_if_user_does_not_exist(self, data_api_client):
-        data_api_client.get_user.return_value = None
+    def test_should_render_create_user_page_if_user_does_not_exist(self):
+        self.data_api_client.get_user.return_value = None
         page_titles = ["Create a new Digital Marketplace account", "Add your name and create a password"]
         button_values = ['Create account'] * 2  # the same for now
 
@@ -112,14 +119,13 @@ class TestCreateUser(BaseApplicationTest):
             ]:
                 assert message in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_render_an_error_if_already_registered_as_a_buyer(self, data_api_client):
+    def test_should_render_an_error_if_already_registered_as_a_buyer(self):
         error_messages = [
             'Account already exists',
             'The details you provided are registered with another supplier.'
         ]
         for role, error_message in zip(self.user_roles, error_messages):
-            data_api_client.get_user.return_value = self.user(
+            self.data_api_client.get_user.return_value = self.user(
                 123,
                 'test@email.com',
                 1 if role == 'supplier' else None,
@@ -136,14 +142,13 @@ class TestCreateUser(BaseApplicationTest):
             assert res.status_code == 400
             assert error_message in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_if_already_registered_as_a_supplier(self, data_api_client):
+    def test_should_return_an_error_if_already_registered_as_a_supplier(self):
         page_headings = [
             'Your email address is already registered as an account with ‘Supplier’.',
             'The details you provided are registered with another supplier.'
         ]
         for role, heading in zip(self.user_roles, page_headings):
-            data_api_client.get_user.return_value = self.user(
+            self.data_api_client.get_user.return_value = self.user(
                 999,
                 'test@email.com',
                 1234,
@@ -158,10 +163,9 @@ class TestCreateUser(BaseApplicationTest):
             assert res.status_code == 400
             assert heading in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_if_already_registered_as_an_admin(self, data_api_client):
+    def test_should_return_an_error_if_already_registered_as_an_admin(self):
         for role in self.user_roles:
-            data_api_client.get_user.return_value = self.user(
+            self.data_api_client.get_user.return_value = self.user(
                 123,
                 'test@email.com',
                 None,
@@ -178,10 +182,9 @@ class TestCreateUser(BaseApplicationTest):
             assert res.status_code == 400
             assert "Account already exists" in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_with_locked_message_if_user_is_locked(self, data_api_client):
+    def test_should_return_an_error_with_locked_message_if_user_is_locked(self):
         for role in self.user_roles:
-            data_api_client.get_user.return_value = self.user(
+            self.data_api_client.get_user.return_value = self.user(
                 123,
                 'test@email.com',
                 1 if role == 'supplier' else None,
@@ -198,10 +201,9 @@ class TestCreateUser(BaseApplicationTest):
             assert res.status_code == 400
             assert "Your account has been locked" in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_with_inactive_message_if_user_is_not_active(self, data_api_client):
+    def test_should_return_an_error_with_inactive_message_if_user_is_not_active(self):
         for role in self.user_roles:
-            data_api_client.get_user.return_value = self.user(
+            self.data_api_client.get_user.return_value = self.user(
                 123,
                 'test@email.com',
                 1 if role == 'supplier' else None,
@@ -218,9 +220,8 @@ class TestCreateUser(BaseApplicationTest):
             assert res.status_code == 400
             assert "Your account has been deactivated" in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_with_wrong_supplier_message_if_invited_by_wrong_supplier(self, data_api_client):  # noqa
-        data_api_client.get_user.return_value = self.user(
+    def test_should_return_an_error_with_wrong_supplier_message_if_invited_by_wrong_supplier(self):
+        self.data_api_client.get_user.return_value = self.user(
             123,
             'test@email.com',
             1234,
@@ -297,6 +298,15 @@ class TestCreateUser(BaseApplicationTest):
 class TestSubmitCreateUser(BaseApplicationTest):
 
     user_roles = ['buyer', 'supplier']
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.create_user.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super().teardown_method(method)
 
     def _generate_token(self, email_address='test@email.com', role='buyer'):
         token_data = {
@@ -409,9 +419,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
             ]:
                 assert message in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_create_buyer_user_if_user_does_not_exist(self, data_api_client):
-        data_api_client.create_user.return_value = {
+    def test_should_create_buyer_user_if_user_does_not_exist(self):
+        self.data_api_client.create_user.return_value = {
             "users": {
                 "id": "1234",
                 "emailAddress": "test@email.com",
@@ -419,7 +428,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
                 "role": "buyer"
             }
         }
-        data_api_client.get_user.return_value = None
+        self.data_api_client.get_user.return_value = None
 
         token = self._generate_token(role='buyer')
         res = self.client.post(
@@ -431,7 +440,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
@@ -443,9 +452,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
         assert res.location == 'http://localhost/'
         self.assert_flashes('/?account-created=true', 'track-page-view')
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_create_suplier_user_if_user_does_not_exist(self, data_api_client):
-        data_api_client.create_user.return_value = {
+    def test_should_create_suplier_user_if_user_does_not_exist(self):
+        self.data_api_client.create_user.return_value = {
             "users": {
                 "id": "1234",
                 "emailAddress": "test@email.com",
@@ -467,7 +475,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'supplier',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
@@ -479,9 +487,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
         assert res.location == 'http://localhost/suppliers'
         self.assert_flashes('/suppliers?account-created=true', 'track-page-view')
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_if_buyer_user_exists(self, data_api_client):
-        data_api_client.create_user.side_effect = HTTPError(mock.Mock(status_code=409))
+    def test_should_return_an_error_if_buyer_user_exists(self):
+        self.data_api_client.create_user.side_effect = HTTPError(mock.Mock(status_code=409))
 
         token = self._generate_token(role='buyer')
         res = self.client.post(
@@ -493,7 +500,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
@@ -503,9 +510,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
         assert res.status_code == 400
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_if_supplier_user_exists(self, data_api_client):
-        data_api_client.create_user.side_effect = HTTPError(mock.Mock(status_code=409))
+    def test_should_return_an_error_if_supplier_user_exists(self):
+        self.data_api_client.create_user.side_effect = HTTPError(mock.Mock(status_code=409))
 
         token = self._generate_token(role='supplier')
         res = self.client.post(
@@ -516,7 +522,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'supplier',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
@@ -526,9 +532,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
         assert res.status_code == 400
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_create_buyer_user_if_no_phone_number(self, data_api_client):
-        data_api_client.create_user.return_value = {
+    def test_should_create_buyer_user_if_no_phone_number(self):
+        self.data_api_client.create_user.return_value = {
             "users": {
                 "id": "1234",
                 "emailAddress": "test@email.com",
@@ -547,7 +552,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
@@ -558,8 +563,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == 'http://localhost/'
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_return_an_error_if_bad_phone_number(self, data_api_client):
+    def test_should_return_an_error_if_bad_phone_number(self):
 
         token = self._generate_token(role='buyer')
         res = self.client.post(
@@ -573,9 +577,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
         assert res.status_code == 400
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_strip_whitespace_surrounding_create_user_name_field(self, data_api_client):
-        data_api_client.create_user.return_value = {
+    def test_should_strip_whitespace_surrounding_create_user_name_field(self):
+        self.data_api_client.create_user.return_value = {
             "users": {
                 "id": "1234",
                 "emailAddress": "test@email.com",
@@ -583,7 +586,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
                 "role": "buyer",
             }
         }
-        data_api_client.get_user.return_value = None
+        self.data_api_client.get_user.return_value = None
         token = self._generate_token(role='buyer')
         self.client.post(
             '/user/create/{}'.format(token),
@@ -594,7 +597,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
@@ -602,9 +605,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
             'name': 'valid name'
         })
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_not_strip_whitespace_surrounding_create_user_password_field(self, data_api_client):
-        data_api_client.create_user.return_value = {
+    def test_should_not_strip_whitespace_surrounding_create_user_password_field(self):
+        self.data_api_client.create_user.return_value = {
             "users": {
                 "id": "1234",
                 "emailAddress": "test@email.com",
@@ -623,7 +625,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
             }
         )
 
-        data_api_client.create_user.assert_called_once_with({
+        self.data_api_client.create_user.assert_called_once_with({
             'role': 'buyer',
             'password': '  validpassword  ',
             'emailAddress': 'test@email.com',
@@ -631,9 +633,8 @@ class TestSubmitCreateUser(BaseApplicationTest):
             'phoneNumber': '020-7930-4832',
         })
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_be_a_503_if_api_fails(self, data_api_client):
-        data_api_client.create_user.side_effect = HTTPError("bad email")
+    def test_should_be_a_503_if_api_fails(self):
+        self.data_api_client.create_user.side_effect = HTTPError("bad email")
 
         token = self._generate_token(role='buyer')
         res = self.client.post(
@@ -645,9 +646,10 @@ class TestSubmitCreateUser(BaseApplicationTest):
         )
         assert res.status_code == 503
 
-    @mock.patch('app.main.views.create_user.data_api_client')
-    def test_should_render_error_page_if_invalid_buyer_domain(self, data_api_client):
-        data_api_client.create_user.side_effect = HTTPError(mock.Mock(status_code=400), message='invalid_buyer_domain')
+    def test_should_render_error_page_if_invalid_buyer_domain(self):
+        self.data_api_client.create_user.side_effect = HTTPError(
+            mock.Mock(status_code=400), message='invalid_buyer_domain'
+        )
 
         token = self._generate_token(role='buyer')
         res = self.client.post(

--- a/tests/main/views/test_notifications.py
+++ b/tests/main/views/test_notifications.py
@@ -6,19 +6,17 @@ import mock
 class TestUserResearchNotifications(BaseApplicationTest):
 
     def setup_method(self, method):
-        super(TestUserResearchNotifications, self).setup_method(method)
+        super().setup_method(method)
 
-        data_api_client_config = {'authenticate_user.return_value': self.user(
+        self.data_api_client_auth_patch = mock.patch('app.main.views.auth.data_api_client', autospec=True)
+        self.data_api_client_auth = self.data_api_client_auth_patch.start()
+        self.data_api_client_auth.authenticate_user.return_value = self.user(
             123, "email@email.com", 1234, 'name', 'name'
-        )}
-
-        self._data_api_client = mock.patch(
-            'app.main.views.auth.data_api_client', **data_api_client_config
         )
-        self.data_api_client_mock = self._data_api_client.start()
 
     def teardown_method(self, method):
-        self._data_api_client.stop()
+        self.data_api_client_auth_patch.stop()
+        super().teardown_method(method)
 
     def test_should_show_login_page(self):
         res = self.client.get("/user/notifications/user-research")

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -81,189 +81,173 @@ class TestResetPassword(BaseApplicationTest):
         self.data_api_client_mock.get_user.assert_called_with(email_address='email@email.com')
 
     def test_email_should_be_decoded_from_token(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
         res = self.client.get(url)
         assert res.status_code == 200
         assert "Reset password for email@email.com" in res.get_data(as_text=True)
 
     def test_password_should_not_be_empty(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password': '',
-                'confirm_password': ''
-            })
-            assert res.status_code == 400
-            assert NEW_PASSWORD_EMPTY_ERROR in res.get_data(as_text=True)
-            assert NEW_PASSWORD_CONFIRM_EMPTY_ERROR in res.get_data(as_text=True)
+        res = self.client.post(url, data={
+            'password': '',
+            'confirm_password': ''
+        })
+        assert res.status_code == 400
+        assert NEW_PASSWORD_EMPTY_ERROR in res.get_data(as_text=True)
+        assert NEW_PASSWORD_CONFIRM_EMPTY_ERROR in res.get_data(as_text=True)
 
     def test_password_should_be_over_ten_chars_long(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password': '123456789',
-                'confirm_password': '123456789'
-            })
-            assert res.status_code == 400
-            assert PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
+        res = self.client.post(url, data={
+            'password': '123456789',
+            'confirm_password': '123456789'
+        })
+        assert res.status_code == 400
+        assert PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
 
     def test_password_should_be_under_51_chars_long(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password':
-                    '123456789012345678901234567890123456789012345678901',
-                'confirm_password':
-                    '123456789012345678901234567890123456789012345678901'
-            })
-            assert res.status_code == 400
-            assert PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
+        res = self.client.post(url, data={
+            'password':
+                '123456789012345678901234567890123456789012345678901',
+            'confirm_password':
+                '123456789012345678901234567890123456789012345678901'
+        })
+        assert res.status_code == 400
+        assert PASSWORD_INVALID_ERROR in res.get_data(as_text=True)
 
     def test_passwords_should_match(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password': '1234567890',
-                'confirm_password': '0123456789'
-            })
-            assert res.status_code == 400
-            assert PASSWORD_MISMATCH_ERROR in res.get_data(as_text=True)
+        res = self.client.post(url, data={
+            'password': '1234567890',
+            'confirm_password': '0123456789'
+        })
+        assert res.status_code == 400
+        assert PASSWORD_MISMATCH_ERROR in res.get_data(as_text=True)
 
     def test_redirect_to_login_page_on_success(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password': '1234567890',
-                'confirm_password': '1234567890'
-            })
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/user/login'
-            res = self.client.get(res.location)
+        res = self.client.post(url, data={
+            'password': '1234567890',
+            'confirm_password': '1234567890'
+        })
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/user/login'
+        res = self.client.get(res.location)
 
-            assert reset_password.PASSWORD_UPDATED_MESSAGE in res.get_data(as_text=True)
+        assert reset_password.PASSWORD_UPDATED_MESSAGE in res.get_data(as_text=True)
 
     def test_password_change_unknown_failure(self):
         self.data_api_client_mock.update_user_password.return_value = False
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password': '1234567890',
-                'confirm_password': '1234567890'
-            })
-            assert res.status_code == 302
-            assert res.location == 'http://localhost/user/login'
-            res = self.client.get(res.location)
+        res = self.client.post(url, data={
+            'password': '1234567890',
+            'confirm_password': '1234567890'
+        })
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/user/login'
+        res = self.client.get(res.location)
 
-            assert reset_password.PASSWORD_NOT_UPDATED_MESSAGE in res.get_data(as_text=True)
+        assert reset_password.PASSWORD_NOT_UPDATED_MESSAGE in res.get_data(as_text=True)
         self.data_api_client_mock.update_user_password.return_value = True
 
     def test_should_not_strip_whitespace_surrounding_reset_password_password_field(self):
-        with self.app.app_context():
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            self.client.post(url, data={
-                'password': '  1234567890',
-                'confirm_password': '  1234567890'
-            })
-            self.data_api_client_mock.update_user_password.assert_called_with(
-                self._user.get('user'), '  1234567890', self._user.get('email'))
+        self.client.post(url, data={
+            'password': '  1234567890',
+            'confirm_password': '  1234567890'
+        })
+        self.data_api_client_mock.update_user_password.assert_called_with(
+            self._user.get('user'), '  1234567890', self._user.get('email'))
 
     @mock.patch('app.main.views.reset_password.data_api_client')
-    def test_token_created_before_last_updated_password_cannot_be_used(
-            self, data_api_client
-    ):
-        with self.app.app_context():
-            data_api_client.get_user.return_value = self.user(
-                123, "email@email.com", 1234, 'email', 'Name', is_token_valid=False
-            )
-            token = generate_token(
-                self._user,
-                self.app.config['SHARED_EMAIL_KEY'],
-                self.app.config['RESET_PASSWORD_SALT'])
-            url = '/user/reset-password/{}'.format(token)
+    def test_token_created_before_last_updated_password_cannot_be_used(self, data_api_client):
+        data_api_client.get_user.return_value = self.user(
+            123, "email@email.com", 1234, 'email', 'Name', is_token_valid=False
+        )
+        token = generate_token(
+            self._user,
+            self.app.config['SHARED_EMAIL_KEY'],
+            self.app.config['RESET_PASSWORD_SALT'])
+        url = '/user/reset-password/{}'.format(token)
 
-            res = self.client.post(url, data={
-                'password': '1234567890',
-                'confirm_password': '1234567890'
-            }, follow_redirects=True)
+        res = self.client.post(url, data={
+            'password': '1234567890',
+            'confirm_password': '1234567890'
+        }, follow_redirects=True)
 
-            assert res.status_code == 200
-            document = html.fromstring(res.get_data(as_text=True))
-            error_selector = cssselect.CSSSelector('div.banner-destructive-without-action')
-            error_elements = error_selector(document)
-            assert len(error_elements) == 1
-            assert reset_password.EXPIRED_PASSWORD_RESET_TOKEN_MESSAGE in error_elements[0].text_content()
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+        error_selector = cssselect.CSSSelector('div.banner-destructive-without-action')
+        error_elements = error_selector(document)
+        assert len(error_elements) == 1
+        assert reset_password.EXPIRED_PASSWORD_RESET_TOKEN_MESSAGE in error_elements[0].text_content()
 
     @mock.patch('app.main.views.reset_password.DMNotifyClient.send_email')
     def test_should_call_send_email_with_correct_params(self, send_email):
-        with self.app.app_context():
-            res = self.client.post(
-                '/user/reset-password',
-                data={'email_address': 'email@email.com'}
-            )
+        res = self.client.post(
+            '/user/reset-password',
+            data={'email_address': 'email@email.com'}
+        )
 
-            assert res.status_code == 302
-            send_email.assert_called_once_with(
-                "email@email.com",
-                template_id='7501026e-d0ba-4cd1-b64f-6a19e1f0913f',
-                personalisation={
-                    'url': MockMatcher(lambda x: '/user/reset-password/gAAAA' in x),
-                },
-                reference='reset-password-8yc90Y2VvBnVHT5jVuSmeebxOCRJcnKicOe7VAsKu50='
-            )
+        assert res.status_code == 302
+        send_email.assert_called_once_with(
+            "email@email.com",
+            template_id='7501026e-d0ba-4cd1-b64f-6a19e1f0913f',
+            personalisation={
+                'url': MockMatcher(lambda x: '/user/reset-password/gAAAA' in x),
+            },
+            reference='reset-password-8yc90Y2VvBnVHT5jVuSmeebxOCRJcnKicOe7VAsKu50='
+        )
 
     @mock.patch('app.main.views.reset_password.DMNotifyClient.send_email')
-    def test_should_be_an_error_if_send_email_fails(
-            self, send_email
-    ):
-        with self.app.app_context():
+    def test_should_be_an_error_if_send_email_fails(self, send_email):
+        send_email.side_effect = EmailError(Exception('API is down'))
 
-            send_email.side_effect = EmailError(Exception('API is down'))
+        res = self.client.post(
+            '/user/reset-password',
+            data={'email_address': 'email@email.com'}
+        )
 
-            res = self.client.post(
-                '/user/reset-password',
-                data={'email_address': 'email@email.com'}
-            )
-
-            assert res.status_code == 503
-            assert PASSWORD_RESET_EMAIL_ERROR in res.get_data(as_text=True)
+        assert res.status_code == 503
+        assert PASSWORD_RESET_EMAIL_ERROR in res.get_data(as_text=True)

--- a/tests/main/views/test_status.py
+++ b/tests/main/views/test_status.py
@@ -7,13 +7,14 @@ import mock
 class TestStatus(BaseApplicationTest):
 
     def setup_method(self, method):
-        super(TestStatus, self).setup_method(method)
+        super().setup_method(method)
 
         self._data_api_client_patch = mock.patch('app.main.views.status.data_api_client', autospec=True)
         self._data_api_client = self._data_api_client_patch.start()
 
     def teardown_method(self, method):
         self._data_api_client_patch.stop()
+        super().teardown_method(method)
 
     def test_should_return_200_from_elb_status_check(self):
         status_response = self.client.get('/user/_status?ignore-dependencies')


### PR DESCRIPTION
Following on from the Briefs FE test refactor (https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/93), refactoring to standardise test classes as follows:

- remove unnecessary `self.app.app_context` contexts (not required for FE app tests)
- `super(TestClassName, self)` ---> `super()` for Python 3
- patch Data API client at setup/teardown level instead of decorators, to tidy parameters and avoid accidentally patching a single API method rather than the whole API.
- ensuring `teardown()` methods include `super()` 

The `TestUserResearchNotifications` class uses functions that import the API from two modules (`auth.py` and `notifications.py`), so two patches are required.