### PR TITLE
Validation masthead error message ordering should match fields

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -32,7 +32,16 @@ class EmailAddressForm(FlaskForm):
     )
 
 
-class PasswordResetForm(FlaskForm):
+class PasswordChangeForm(FlaskForm):
+    """
+    Fields have numbered prefixes to allow ordering of error messages in the validation masthead
+    """
+    old_password = PasswordField(
+        'Old password', id="input_old_password",
+        validators=[
+            DataRequired(message="You must enter your old password"),
+        ]
+    )
     password = PasswordField(
         'New password', id="input_password",
         validators=[
@@ -52,16 +61,12 @@ class PasswordResetForm(FlaskForm):
     )
 
 
-class PasswordChangeForm(PasswordResetForm):
+class PasswordResetForm(PasswordChangeForm):
     """
-    Subclasses PasswordResetForm so we can keep validation/password policy in one place
+    Subclasses PasswordChangeForm so we can keep validation/password policy in one place
+    'Old password' not required for PasswordReset (as the user likely doesn't know it)
     """
-    old_password = PasswordField(
-        'Old password', id="input_old_password",
-        validators=[
-            DataRequired(message="You must enter your old password"),
-        ]
-    )
+    old_password = None
 
 
 class CreateUserForm(FlaskForm):

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -33,9 +33,6 @@ class EmailAddressForm(FlaskForm):
 
 
 class PasswordChangeForm(FlaskForm):
-    """
-    Fields have numbered prefixes to allow ordering of error messages in the validation masthead
-    """
     old_password = PasswordField(
         'Old password', id="input_old_password",
         validators=[

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collections import OrderedDict
 from flask import abort, current_app, flash, redirect, render_template, request, url_for, Markup
 from flask_login import current_user, login_required
 
@@ -146,6 +147,7 @@ def update_password(token):
 @login_required
 def change_password():
     form = PasswordChangeForm()
+    errors = {}
     dashboard_url = get_user_dashboard_url(current_user)
 
     if request.method == 'POST':
@@ -213,7 +215,19 @@ def change_password():
 
                 form.old_password.errors.append("Make sure you’ve entered the right password.")
 
-        return render_template("auth/change-password.html", form=form, dashboard_url=dashboard_url), 400
+        if form.errors:
+            # Format errors as a nested ordered dict for use with toolkit templates
+            errors = OrderedDict(
+                (key, {'question': form[key].label.text, 'input_name': key, 'message': form[key].errors[0]})
+                for key in form.errors.keys()
+            )
+
+        return render_template(
+            "auth/change-password.html",
+            form=form,
+            errors=errors,
+            dashboard_url=dashboard_url
+        ), 400
 
     else:
         return render_template(

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -21,19 +21,10 @@
 
 {% block main_content %}
 
-{% if form.errors %}
-    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h3>
-        <ul>
-        {% for field_name, field_errors in form.errors|dictsort|reverse if field_errors %}
-          {% for error in field_errors %}
-            <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
-          {% endfor %}
-        {% endfor %}
-        </ul>
-    </div>
+{% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
 {% endif %}
 
 {% with

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.5.0#egg=digitalmarketplace-utils==36.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.0#egg=digitalmarketplace-utils==36.10.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.5.0#egg=digitalmarketplace-utils==36.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.0#egg=digitalmarketplace-utils==36.10.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -39,7 +39,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.6.1
-python-dateutil==2.7.2
+python-dateutil==2.7.3
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -98,6 +98,11 @@ class TestResetPassword(BaseApplicationTest):
         assert res.status_code == 200
         assert "Reset password for email@email.com" in res.get_data(as_text=True)
 
+        # Reset form should not display the 'Old password' field
+        document = html.fromstring(res.get_data(as_text=True))
+        form_labels = document.xpath('//main//form//label/text()')
+        assert form_labels == ['New password', 'Confirm new password']
+
     def test_password_should_not_be_empty(self):
         token = generate_token(
             self._user,


### PR DESCRIPTION
Trello: https://trello.com/c/TieWrBG5/44-password-reset-link-from-logged-in-session

![change-password-masthead](https://user-images.githubusercontent.com/3492540/39866465-c6a642d8-5448-11e8-85b8-dd6b83e3db3d.png)

Following QA of the change password form on preview. The error fields in the validation masthead now match the ordering of the form fields.

This requires adding a numbered prefix to the field's `id`, so we can sort non-alphabetically. WTForms doesn't seem to have a specific sort order functionality - it relies on declaration order, but we're subclassing another form so the ordering is jumbled. This doesn't seem ideal, any suggestions welcome.

Also pulls in updated utils, which fixes a small bug in the password reset token decoding (see https://github.com/alphagov/digitalmarketplace-utils/pull/392).