### PR TITLE
Change password hint text wording

### DIFF
--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -81,9 +81,7 @@
             {% endif %}
                 <div class="question" id="{{ form.confirm_password.name }}">
                     {{ form.confirm_password.label(class="question-heading") }}
-                    <p class="hint">
-                        Repeat password used above
-                    </p>
+
                     {% if form.confirm_password.errors %}
                     <p class="validation-message" id="error-confirm-password-textbox">
                         {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -58,9 +58,7 @@
             {% endif %}
                 <div class="question" id="{{ form.confirm_password.name }}">
                     {{ form.confirm_password.label(class="question-heading") }}
-                    <p class="hint">
-                        Repeat password used above
-                    </p>
+
                     {% if form.confirm_password.errors %}
                     <p class="validation-message" id="error-confirm-password-textbox">
                         {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}


### PR DESCRIPTION
Trello: https://trello.com/c/TieWrBG5/44-password-reset-link-from-logged-in-session

Following a requested content change on the password change form to remove hint text - previously was `Repeat password used above`. I've updated the password reset form where this was copied from as well: 
![change-password-no-hint-text](https://user-images.githubusercontent.com/3492540/40057216-8975e124-5845-11e8-88e4-c23c6c17b7a4.png)

