### PR TITLE
Consolidate validation mastheads

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -4,6 +4,12 @@ from wtforms.validators import DataRequired, EqualTo, Length, Regexp
 from dmutils.forms import StripWhitespaceStringField, StringField
 
 
+EMAIL_LOGIN_HINT = "Enter the email address you used to register with the Digital Marketplace"
+PASSWORD_HINT = "Must be between 10 and 50 characters"
+PHONE_NUMBER_HINT = "If there are any urgent problems with your requirements, we need your phone number so the " \
+                    "support team can help you fix them quickly."
+
+
 class LoginForm(FlaskForm):
     email_address = StripWhitespaceStringField(
         'Email address', id="input_email_address",
@@ -19,6 +25,10 @@ class LoginForm(FlaskForm):
             DataRequired(message="You must provide your password")
         ]
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.email_address.hint = EMAIL_LOGIN_HINT
 
 
 class EmailAddressForm(FlaskForm):
@@ -56,6 +66,10 @@ class PasswordChangeForm(FlaskForm):
             EqualTo('password', message="The passwords you entered do not match")
         ]
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.password.hint = PASSWORD_HINT
 
 
 class PasswordResetForm(PasswordChangeForm):
@@ -98,3 +112,8 @@ class CreateUserForm(FlaskForm):
                    )
         ]
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.phone_number.hint = PHONE_NUMBER_HINT
+        self.password.hint = PASSWORD_HINT

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -13,6 +13,7 @@ from flask import (
 )
 from flask_login import logout_user, login_user
 
+from dmutils.forms import get_errors_from_wtform
 from dmutils.user import User
 from dmutils.email.helpers import hash_string
 
@@ -32,9 +33,14 @@ def render_login():
     next_url = request.args.get('next')
     if current_user.is_authenticated() and not get_flashed_messages():
         return redirect_logged_in_user(next_url)
+
+    form = LoginForm()
+    errors = get_errors_from_wtform(form)
+
     return render_template(
         "auth/login.html",
-        form=LoginForm(),
+        form=form,
+        errors=errors,
         next=next_url), 200
 
 
@@ -54,6 +60,7 @@ def process_login():
             return render_template(
                 "auth/login.html",
                 form=form,
+                errors=get_errors_from_wtform(form),
                 next=next_url), 403
 
         user = User.from_json(user_json)
@@ -64,9 +71,11 @@ def process_login():
         return redirect_logged_in_user(next_url)
 
     else:
+        errors = get_errors_from_wtform(form)
         return render_template(
             "auth/login.html",
             form=form,
+            errors=errors,
             next=next_url), 400
 
 

--- a/app/main/views/create_user.py
+++ b/app/main/views/create_user.py
@@ -3,6 +3,7 @@ from flask_login import login_user
 
 from dmapiclient import HTTPError
 from dmutils.email import decode_invitation_token
+from dmutils.forms import get_errors_from_wtform
 from dmutils.user import User
 
 from .. import main
@@ -53,6 +54,7 @@ def create_user(encoded_token):
             "auth/create-user.html",
             email_address=token['email_address'],
             form=form,
+            errors=get_errors_from_wtform(form),
             role=role,
             supplier_name=token.get('supplier_name'),
             token=encoded_token), 200
@@ -101,6 +103,7 @@ def submit_create_user(encoded_token):
             "auth/create-user.html",
             email_address=token['email_address'],
             form=form,
+            errors=get_errors_from_wtform(form),
             role=role,
             supplier_name=token.get('supplier_name'),
             token=encoded_token), 400

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -6,6 +6,9 @@ from flask import (
     request,
     redirect
 )
+
+from dmutils.forms import get_errors_from_wtform
+
 from .. import main
 from ..forms.user_research import UserResearchOptInForm
 from ..helpers.login_helpers import get_user_dashboard_url
@@ -39,10 +42,7 @@ def user_research_consent():
         else:
             # If the form is not valid set the status code and parse the errors into an acceptable format.
             status_code = 400
-            errors = {
-                key: {'question': form[key].label.text, 'input_name': key, 'message': form[key].errors[0]}
-                for key, value in form.errors.items()
-            }
+            errors = get_errors_from_wtform(form)
     else:
         # Update the form with the existing value if this is not a POST
         user = data_api_client.get_user(current_user.id)

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask import abort, current_app, flash, redirect, render_template, request, url_for, Markup
+from flask import abort, current_app, flash, redirect, render_template, url_for, Markup
 from flask_login import current_user, login_required
 
 from dmutils.email import DMNotifyClient, generate_token, decode_password_reset_token, EmailError
@@ -153,85 +153,61 @@ def change_password():
     form = PasswordChangeForm()
     dashboard_url = get_user_dashboard_url(current_user)
 
-    if request.method == 'POST':
-        if form.validate_on_submit():
-            # Make sure old password is valid
-            user_json = data_api_client.authenticate_user(
-                current_user.email_address,
-                form.old_password.data)
-            if user_json:
-                response = data_api_client.update_user_password(
-                    current_user.id,
-                    form.password.data,
-                    updater=current_user.email_address
+    # Checking that the old password is correct is done as a validator on the form.
+    if form.validate_on_submit():
+        response = data_api_client.update_user_password(current_user.id, form.password.data,
+                                                        updater=current_user.email_address)
+        if response:
+            current_app.logger.info(
+                "User {user_id} successfully changed their password",
+                extra={'user_id': current_user.id}
+            )
+
+            notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
+
+            token = generate_token(
+                {
+                    "user": current_user.id
+                },
+                current_app.config['SHARED_EMAIL_KEY'],
+                current_app.config['RESET_PASSWORD_SALT']
+            )
+
+            try:
+                notify_client.send_email(
+                    current_user.email_address,
+                    template_id=current_app.config['NOTIFY_TEMPLATES']['change_password_alert'],
+                    personalisation={
+                        'url': url_for('main.reset_password', token=token, _external=True),
+                    },
+                    reference='change-password-alert-{}'.format(hash_string(current_user.email_address))
                 )
-                if response:
-                    current_app.logger.info(
-                        "User {user_id} successfully changed their password",
-                        extra={'user_id': current_user.id}
-                    )
 
-                    notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
-
-                    token = generate_token(
-                        {
-                            "user": current_user.id
-                        },
-                        current_app.config['SHARED_EMAIL_KEY'],
-                        current_app.config['RESET_PASSWORD_SALT']
-                    )
-
-                    try:
-                        notify_client.send_email(
-                            current_user.email_address,
-                            template_id=current_app.config['NOTIFY_TEMPLATES']['change_password_alert'],
-                            personalisation={
-                                'url': url_for('main.reset_password', token=token, _external=True),
-                            },
-                            reference='change-password-alert-{}'.format(hash_string(current_user.email_address))
-                        )
-
-                        current_app.logger.info(
-                            "{code}: Password change alert email sent for email_hash {email_hash}",
-                            extra={
-                                'email_hash': hash_string(current_user.email_address),
-                                'code': 'login.password-change-alert-email.sent'
-                            }
-                        )
-
-                    except EmailError as exc:
-                        log_email_error(
-                            exc,
-                            "Password change alert",
-                            "login.password-change-alert-email.notify-error",
-                            current_user.email_address
-                        )
-
-                    flash(PASSWORD_UPDATED_MESSAGE)
-                else:
-                    flash(PASSWORD_NOT_UPDATED_MESSAGE, 'error')
-                return redirect(dashboard_url)
-            else:
                 current_app.logger.info(
-                    "change_password.fail: failed to authenticate user {email_hash}",
-                    extra={'email_hash': hash_string(current_user.email_address)})
+                    "{code}: Password change alert email sent for email_hash {email_hash}",
+                    extra={
+                        'email_hash': hash_string(current_user.email_address),
+                        'code': 'login.password-change-alert-email.sent'
+                    }
+                )
 
-                form.old_password.errors.append("Make sure you’ve entered the right password.")
+            except EmailError as exc:
+                log_email_error(
+                    exc,
+                    "Password change alert",
+                    "login.password-change-alert-email.notify-error",
+                    current_user.email_address
+                )
 
-        errors = get_errors_from_wtform(form)
-        return render_template(
-            "auth/change-password.html",
-            form=form,
-            errors=errors,
-            dashboard_url=dashboard_url
-        ), 400
+            flash(PASSWORD_UPDATED_MESSAGE)
+        else:
+            flash(PASSWORD_NOT_UPDATED_MESSAGE, 'error')
+        return redirect(dashboard_url)
 
-    else:
-        form = PasswordChangeForm()
-        errors = get_errors_from_wtform(form)
-        return render_template(
-            "auth/change-password.html",
-            form=form,
-            errors=errors,
-            dashboard_url=dashboard_url
-        ), 200
+    errors = get_errors_from_wtform(form)
+    return render_template(
+        "auth/change-password.html",
+        form=form,
+        errors=errors,
+        dashboard_url=dashboard_url
+    ), 200 if not errors else 400

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -20,12 +20,7 @@
 {% endblock %}
 
 {% block main_content %}
-
-{% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-{% endif %}
+  {% include 'toolkit/forms/validation.html' %}
 
 {% with
   heading = "Change your password"
@@ -38,60 +33,37 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             {{ form.hidden_tag() }}
-
-
-            {% if form.old_password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.old_password.name }}">
-                    {{ form.old_password.label(class="question-heading") }}
-                    {% if form.old_password.errors %}
-                    <p class="validation-message" id="error-old-password-textbox">
-                        {% for error in form.old_password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.old_password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.old_password.errors %}
-                </div>
-            {% endif %}
-
-
-            {% if form.password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.password.name }}">
-                    {{ form.password.label(class="question-heading") }}
-                    <p class="hint">
-                      Must be between 10 and 50 characters
-                    </p>
-                    {% if form.password.errors %}
-                    <p class="validation-message" id="error-password-textbox">
-                        {% for error in form.password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.password.errors %}
-                </div>
-            {% endif %}
-
-            {% if form.confirm_password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.confirm_password.name }}">
-                    {{ form.confirm_password.label(class="question-heading") }}
-
-                    {% if form.confirm_password.errors %}
-                    <p class="validation-message" id="error-confirm-password-textbox">
-                        {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.confirm_password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.confirm_password.errors %}
-                </div>
-            {% endif %}
+          
+            {% with question = form.old_password.label,
+                    name = "old_password",
+                    error = errors.get('old_password', {}).get('message'),
+                    value = form.old_password.data,
+                    type = "password",
+                    autocomplete = "off"
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
+  
+          {% with question = form.password.label,
+                  name = "password",
+                  error = errors.get('password', {}).get('message'),
+                  hint = form.password.hint,
+                  value = form.password.data,
+                  type = "password",
+                  autocomplete = "off"
+          %}
+            {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
+  
+          {% with question = form.confirm_password.label,
+                  name = "confirm_password",
+                  error = errors.get('confirm_password', {}).get('message'),
+                  value = form.confirm_password.data,
+                  type = "password",
+                  autocomplete = "off"
+          %}
+            {% include "toolkit/forms/textbox.html" %}
+          {% endwith %}
 
             {%
               with

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -42,70 +42,44 @@
         <div class="grid-row">
             <div class="column-two-thirds">
                 {{ form.hidden_tag() }}
-
-                {% if form.name.errors %}
-                <div class="validation-wrapper">
-                    {% endif %}
-                    <div class="question" id="{{ form.name.name }}">
-                        {{ form.name.label(class="question-heading") }}
-                        {% if form.name.errors %}
-                        <p class="validation-message" id="error-name-textbox">
-                            {% for error in form.name.errors %}{{ error }}{% endfor %}
-                        </p>
-                        {% endif %}
-                        {{ form.name(class="text-box", autocomplete="off") }}
-                    </div>
-                    {% if form.name.errors %}
-                </div>
-                {% endif %}
+  
+                {% with question = form.name.label,
+                        name = "name",
+                        error = errors.get('name', {}).get('message'),
+                        value = form.name.data,
+                        autocomplete = "off"
+                %}
+                  {% include "toolkit/forms/textbox.html" %}
+                {% endwith %}
 
                 {% if role == 'buyer' %}
-                  {% if form.phone_number.errors %}
-                      <div class="validation-wrapper">
-                  {% endif %}
-                      <div class="question" id="{{ form.phone_number.name }}">
-                          {{ form.phone_number.label(class="question-heading") }}
-                          <p class="hint">
-                            If there are any urgent problems with your requirements, we need your phone number so the support team can help you fix them quickly.
-                          </p>
-                          {% if form.phone_number.errors %}
-                          <p class="validation-message" id="error-password-textbox">
-                              {% for error in form.phone_number.errors %}{{ error }}{% endfor %}
-                          </p>
-                          {% endif %}
-                          {{ form.phone_number(class="text-box", autocomplete="off") }}
-                      </div>
-                  {% if form.phone_number.errors %}
-                      </div>
-                  {% endif %}
+                  {% with question = form.phone_number.label,
+                          name = "phone_number",
+                          error = errors.get('phone_number', {}).get('message'),
+                          hint = form.phone_number.hint,
+                          value = form.phone_number.data,
+                          autocomplete = "off"
+                  %}
+                    {% include "toolkit/forms/textbox.html" %}
+                  {% endwith %}
                 {% endif %}
+  
+                {% with question = form.password.label,
+                        name = "password",
+                        error = errors.get('password', {}).get('message'),
+                        value = form.password.data,
+                        type = "password"
+                %}
+                  {% include "toolkit/forms/textbox.html" %}
+                {% endwith %}
 
-                {% if form.password.errors %}
-                    <div class="validation-wrapper">
-                {% endif %}
-                    <div class="question" id="{{ form.password.name }}">
-                        {{ form.password.label(class="question-heading") }}
-                        <p class="hint">
-                          Must be between 10 and 50 characters
-                        </p>
-                        {% if form.password.errors %}
-                        <p class="validation-message" id="error-password-textbox">
-                            {% for error in form.password.errors %}{{ error }}{% endfor %}
-                        </p>
-                        {% endif %}
-                        {{ form.password(class="text-box", autocomplete="off") }}
-                    </div>
-                {% if form.password.errors %}
-                    </div>
-                {% endif %}
-
-            {%
-              with
-              type = "save",
-              label = "Create account"
-            %}
-              {% include "toolkit/button.html" %}
-            {% endwith %}
+                {%
+                  with
+                  type = "save",
+                  label = "Create account"
+                %}
+                  {% include "toolkit/button.html" %}
+                {% endwith %}
             </div>
         </div>
     </form>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -30,41 +30,25 @@
         <div class="column-two-thirds">
 
             {{ form.hidden_tag() }}
-
-            {% if form.email_address.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.email_address.name }}">
-                    {{ form.email_address.label(class="question-heading") }}
-                    <p class="hint">
-                        Enter the email address you used to register with the Digital Marketplace
-                    </p>
-                    {% if form.email_address.errors %}
-                    <p class="validation-message" id="error-email-address-textbox">
-                        {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.email_address(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.email_address.errors %}
-                </div>
-            {% endif %}
-
-            {% if form.password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.password.name }}">
-                    {{ form.password.label(class="question-heading") }}
-                    {% if form.password.errors %}
-                    <p class="validation-message" id="error-password-textbox">
-                        {% for error in form.password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.password.errors %}
-                </div>
-            {% endif %}
+  
+            {% with question = form.email_address.label,
+                    name = "email_address",
+                    error = errors.get('email_address', {}).get('message'),
+                    hint = form.email_address.hint,
+                    value = form.email_address.data,
+                    autocomplete = "off"
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
+  
+            {% with question = form.password.label,
+                    name = "password",
+                    error = errors.get('password', {}).get('message'),
+                    value = form.password.data,
+                    type = "password"
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
 
             {%
               with

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -3,21 +3,9 @@
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 
 {% block main_content %}
-
-{% if form.errors %}
-    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h3>
-        <ul>
-        {% for field_name, field_errors in form.errors|dictsort|reverse if field_errors %}
-          {% for error in field_errors %}
-            <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
-          {% endfor %}
-        {% endfor %}
-        </ul>
-    </div>
-{% endif %}
+{% with lede = "There was a problem with the details you gave for:" %}
+  {% include "toolkit/forms/validation.html" %}
+{% endwith %}
 
 {% with
   heading = "Reset password"
@@ -33,42 +21,25 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             {{ form.hidden_tag() }}
-
-            {% if form.password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.password.name }}">
-                    {{ form.password.label(class="question-heading") }}
-                    <p class="hint">
-                      Must be between 10 and 50 characters
-                    </p>
-                    {% if form.password.errors %}
-                    <p class="validation-message" id="error-password-textbox">
-                        {% for error in form.password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.password.errors %}
-                </div>
-            {% endif %}
-
-            {% if form.confirm_password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.confirm_password.name }}">
-                    {{ form.confirm_password.label(class="question-heading") }}
-
-                    {% if form.confirm_password.errors %}
-                    <p class="validation-message" id="error-confirm-password-textbox">
-                        {% for error in form.confirm_password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.confirm_password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.confirm_password.errors %}
-                </div>
-            {% endif %}
+            
+            {% with question = form.password.label,
+                    name = "password",
+                    error = errors.get('password', {}).get('message'),
+                    hint = form.password.hint,
+                    value = form.password.data,
+                    type = "password"
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
+          
+            {% with question = form.confirm_password.label,
+                    name = "confirm_password",
+                    error = errors.get('confirm_password', {}).get('message'),
+                    value = form.confirm_password.data,
+                    type = "password"
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
 
             {%
               with

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -22,12 +22,7 @@
 {% block main_content %}
 
 <div class="grid-row notification-user-research">
-
-  {% if errors %}
-    {% with errors = errors.values() %}
-      {% include 'toolkit/forms/validation.html' %}
-    {% endwith %}
-  {% endif %}
+  {% include 'toolkit/forms/validation.html' %}
 
   <div class="column-two-thirds">
     {% with heading = "{}".format(

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz"
   },
   "scripts": {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@37.0.0#egg=digitalmarketplace-utils==37.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -38,7 +38,7 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.3
+PyJWT==1.6.4
 python-dateutil==2.7.3
 python-json-logger==0.1.4
 pytz==2015.4

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -289,6 +289,10 @@ class TestChangePassword(BaseApplicationTest):
         data_api_client_config = {'get_user.return_value': self.user(
             123, "email@email.com", 1234, 'name', 'Name'
         )}
+        auth_forms_extra_data_api_client_config = {
+            'authenticate_user.return_value': self.user(
+                123, "email@email.com", 1234, 'Supplier Name', 'Name', role='supplier')
+        }
 
         self._user = {
             "user": 123,
@@ -300,8 +304,15 @@ class TestChangePassword(BaseApplicationTest):
         )
         self.data_api_client = self.data_api_client_patch.start()
 
+        self.auth_forms_data_api_client_patch = mock.patch(
+            'app.main.forms.auth_forms.data_api_client', **data_api_client_config,
+            **auth_forms_extra_data_api_client_config
+        )
+        self.auth_forms_data_api_client = self.auth_forms_data_api_client_patch.start()
+
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
+        self.auth_forms_data_api_client.stop()
         super().teardown_method(method)
 
     @pytest.mark.parametrize(
@@ -370,7 +381,7 @@ class TestChangePassword(BaseApplicationTest):
 
     def test_old_password_needs_to_match_user_password(self):
         self.login_as_supplier()
-        self.data_api_client.authenticate_user.return_value = None
+        self.auth_forms_data_api_client.authenticate_user.return_value = None
         response = self.client.post(
             '/user/change-password',
             data={

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -101,7 +101,9 @@ class TestResetPassword(BaseApplicationTest):
         # Reset form should not display the 'Old password' field
         document = html.fromstring(res.get_data(as_text=True))
         form_labels = document.xpath('//main//form//label/text()')
-        assert form_labels == ['New password', 'Confirm new password']
+
+        for label in ['New password', 'Confirm new password']:
+            assert label in form_labels
 
     def test_password_should_not_be_empty(self):
         token = generate_token(

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,9 +515,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
-  version "28.15.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#05167f7a96843fe3e893448a64770ec9dd01684c"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.1.0":
+  version "29.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#fe6073f53641bc03656c4a9b4f1501cf2adee2a9"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
 ## Summary
Use validation masthead from the frontend-toolkit consistently.

Also converts most pages over to using the base page from the frontend-toolkit.

 ## Ticket
https://trello.com/c/RSYEM3FL/448

 ## Requires
https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/440