### PR TITLE
Decrease cookie expiry to 90 days

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -51,6 +51,10 @@ def user_research_consent():
     # Set the seen_user_research_message cookie if it does not exist.
     # This ensures the user research banner is no longer shown.
     additional_headers = []
+
+    # Changing cookie name will require an update to the following files:
+    # digitalmarketplace-frontend-toolkit/toolkit/templates/user-research-consent-banner.html
+    # digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
     cookie_name = 'seen_user_research_message'
 
     if cookie_name not in request.cookies:

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -10,6 +10,7 @@ from .. import main
 from ..forms.user_research import UserResearchOptInForm
 from ..helpers.login_helpers import get_user_dashboard_url
 from ... import data_api_client
+import datetime
 
 
 @main.route('/notifications/user-research', methods=["GET", "POST"])
@@ -53,7 +54,9 @@ def user_research_consent():
     cookie_name = 'seen_user_research_message'
 
     if cookie_name not in request.cookies:
-        additional_headers = {'Set-Cookie': "{}=yes; Path=/".format(cookie_name)}
+        expiry_date = datetime.datetime.now() + datetime.timedelta(90)
+        expiry_date = expiry_date.strftime("%a, %d-%b-%Y %H:%M:%S GMT")
+        additional_headers = {'Set-Cookie': "{}=yes; Path=/; Expires={}".format(cookie_name, expiry_date)}
 
     return render_template(
         "notifications/user-research-consent.html",


### PR DESCRIPTION
Changes

Cookie banner to appear on all pages for logged in and logged out users until they click close or opt in. If clicked close, it reappears after 90 days.

Ticket: https://trello.com/c/48pZNhaG/120-iterate-opt-in-flow-for-user-research-participants