### PR TITLE
Update content for 400 error page

### DIFF
--- a/app/templates/errors/400.html
+++ b/app/templates/errors/400.html
@@ -14,7 +14,7 @@
         {% if error_message %}
           {{ error_message }}
         {% else %}
-          Please try again.
+          Please do not attempt the same request again.
         {% endif %}
       </p>
     </div>


### PR DESCRIPTION
This brings the content in line with the other custom 400 error pages in
the buyer and supplier frontends.