### PR TITLE
Update frontend-toolkit to v31.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,9 +515,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.1.0":
-  version "29.1.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#fe6073f53641bc03656c4a9b4f1501cf2adee2a9"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.2.0":
+  version "31.2.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#d090a253b164e2054636d2b6db81d0136cf330b1"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Includes user research banner CSS tweaks from alphagov/digitalmarketplace-frontend-toolkit#446