### PR TITLE
Use validation template

### DIFF
--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -6,20 +6,9 @@
 
 {% block main_content %}
 
-{% if form.errors %}
-    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h3>
-        <ul>
-        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
-        {% for error in field_errors %}
-          <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
-        {% endfor %}
-        {% endfor %}
-        </ul>
-    </div>
-{% endif %}
+{% with lede = "There was a problem with the details you gave for:" %}
+    {% include 'toolkit/forms/validation.html' %}
+{% endwith %}
 
 {% set headings = {
     'buyer': 'Create a new Digital Marketplace account',

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -4,20 +4,9 @@
 
 {% block main_content %}
 
-{% if form.errors %}
-    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
-        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with the details you gave for:
-        </h3>
-        <ul>
-        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
-        {% for error in field_errors %}
-          <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
-        {% endfor %}
-        {% endfor %}
-        </ul>
-    </div>
-{% endif %}
+{% with lede = "There was a problem with the details you gave for:" %}
+    {% include 'toolkit/forms/validation.html' %}
+{% endwith %}
 
 {% with
   heading = "Log in to the Digital Marketplace"


### PR DESCRIPTION
I thought we'd done this already as part of Sam's refactoring ticket (https://trello.com/c/RSYEM3FL/448-validation-mastheads-should-use-toolkit-template), but it seems not.

There's no spacing between the header and the masthead on these pages, because there are no breadcrumbs (the user is logged out so we can't really have `Digital Marketplace > Your Account`). This is the current situation in production, i.e. this PR is not visually worse than the status quo 😸 