### PR TITLE
Reset password masthead

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -10,6 +10,7 @@ from dmutils.forms import StripWhitespaceStringField
 from app import data_api_client
 
 
+EMAIL_REGEX = "^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$"
 EMAIL_LOGIN_HINT = "Enter the email address you used to register with the Digital Marketplace"
 PASSWORD_HINT = "Must be between 10 and 50 characters"
 PHONE_NUMBER_HINT = "If there are any urgent problems with your requirements, we need your phone number so the " \
@@ -21,7 +22,7 @@ class LoginForm(FlaskForm):
         'Email address', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
+            Regexp(EMAIL_REGEX,
                    message="You must provide a valid email address")
         ]
     )
@@ -42,10 +43,14 @@ class EmailAddressForm(FlaskForm):
         'Email address', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
+            Regexp(EMAIL_REGEX,
                    message="You must provide a valid email address")
         ]
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.email_address.hint = EMAIL_LOGIN_HINT
 
 
 class MatchesCurrentPassword:

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -34,8 +34,11 @@ PASSWORD_NOT_UPDATED_MESSAGE = "Could not update password due to an error."
 
 @main.route('/reset-password', methods=["GET"])
 def request_password_reset():
+    form = EmailAddressForm()
+    errors = get_errors_from_wtform(form)
     return render_template("auth/request-password-reset.html",
-                           form=EmailAddressForm()), 200
+                           errors=errors,
+                           form=form), 200
 
 
 @main.route('/reset-password', methods=["POST"])
@@ -97,6 +100,7 @@ def send_reset_password_email():
         return redirect(url_for('.request_password_reset'))
     else:
         return render_template("auth/request-password-reset.html",
+                               errors=get_errors_from_wtform(form),
                                form=form), 400
 
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -2,6 +2,22 @@
 
 {% block page_title %}Log in – Digital Marketplace{% endblock %}
 
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "label": "Login"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 
 {% with lede = "There was a problem with the details you gave for:" %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -2,6 +2,26 @@
 
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": "/user/login",
+        "label": "Login"
+      },
+      {
+        "label": "Reset password"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 
 <header class="page-heading">

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -24,6 +24,10 @@
 
 {% block main_content %}
 
+{% with lede = "There was a problem with the details you gave for:" %}
+  {% include 'toolkit/forms/validation.html' %}
+{% endwith %}
+
 <header class="page-heading">
     <h1>Reset password</h1>
 </header>
@@ -38,24 +42,15 @@
 
             {{ form.hidden_tag() }}
 
-            {% if form.email_address.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question">
-                    {{ form.email_address.label(class="question-heading") }}
-                    <p class="hint">
-                        Enter the email address you used to register with the Digital Marketplace
-                    </p>
-                    {% if form.email_address.errors %}
-                    <p class="validation-message" id="error-email-address-textbox">
-                        {% for error in form.email_address.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.email_address(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.email_address.errors %}
-                </div>
-            {% endif %}
+            {% with question = form.email_address.label,
+                    name = "email_address",
+                    error = errors.get('email_address', {}).get('message'),
+                    hint = form.email_address.hint,
+                    value = form.email_address.data,
+                    autocomplete = "off"
+            %}
+              {% include "toolkit/forms/textbox.html" %}
+            {% endwith %}
 
             {%
               with

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -2,6 +2,22 @@
 
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "label": "Reset password"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
 {% block main_content %}
 {% with lede = "There was a problem with the details you gave for:" %}
   {% include "toolkit/forms/validation.html" %}


### PR DESCRIPTION
- Add breadcrumbs to login, request password reset and reset password pages.
- Add validation masthead to password reset page .

The password reset page previously did not use the same type of form as the login page. This meant that the form would rely on browser validation messages which are not as visually identifiable as the ones from the dm toolkit.

We now get a validation error masthead with message when the form is submitted with an email or with an invalid email, the same as our login page.

## Before

<img width="970" alt="before" src="https://user-images.githubusercontent.com/3466862/42099285-f0b00b5c-7bb4-11e8-8ab5-144e79a978f7.png">

The above message disappears after a short delay. Screen readers do read out a message: "Email address, required invalid data, edit text". This is not as descriptive as the text used in our masthead validation error messages.

## After

<img width="983" alt="after" src="https://user-images.githubusercontent.com/3466862/42099299-f88606c4-7bb4-11e8-9485-a2fd9d46872c.png">

