### PR TITLE
Update dmutils to v40.8.0 so we can log CSRF errors

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.4.0#egg=digitalmarketplace-apiclient==17.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.6.1#egg=digitalmarketplace-utils==40.6.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.4.0#egg=digitalmarketplace-apiclient==17.4.0
 


### PR DESCRIPTION
Users have been reporting CSRF errors similar to those in [this tech
debt ticket][trello].

alphagov/digitalmarketplace-utils#428 added `flask_wtf.crsf` to the list
of logs that are handled by our logging handlers. This commit pulls in
the version of digitalmarketplace-utils with this change.

It also includes logging for `urllib3.util.retry`, and changes to
timed_render_template.

[trello]: https://trello.com/c/1K5ePclo