### PR TITLE
User FE errors: Pass error status code as kwarg

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -7,4 +7,4 @@ from dmutils.errors import render_error_page
 
 @main.app_errorhandler(APIError)
 def api_error_handler(e):
-    return render_error_page(e.status_code)
+    return render_error_page(status_code=e.status_code)


### PR DESCRIPTION
As per: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/828 

Fixes bug in production where API client errors were not being handled correctly.

BAD:
```
render_error_page(400)
```

GOOD:
```
render_error_page(status_code=400)
```