### PR TITLE
User FE: Update Flask-Login to 0.4.x

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, redirect, session, abort
 from flask_login import LoginManager
-from flask_wtf.csrf import CsrfProtect, CSRFError
+from flask_wtf.csrf import CSRFProtect
 
 import dmapiclient
 from dmutils import init_app, flask_featureflags
@@ -13,7 +13,7 @@ from config import configs
 login_manager = LoginManager()
 data_api_client = dmapiclient.DataAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()
-csrf = CsrfProtect()
+csrf = CSRFProtect()
 
 
 def create_app(config_name):
@@ -40,21 +40,6 @@ def create_app(config_name):
     login_manager.login_view = 'main.render_login'
     login_manager.login_message_category = "must_login"
     csrf.init_app(application)
-
-    @application.errorhandler(CSRFError)
-    def csrf_handler(reason):
-        if 'user_id' not in session:
-            application.logger.info(
-                u'csrf.session_expired: Redirecting user to log in page'
-            )
-
-            return application.login_manager.unauthorized()
-
-        application.logger.info(
-            u'csrf.invalid_token: Aborting request, user_id: {user_id}',
-            extra={'user_id': session['user_id']})
-
-        abort(400, reason)
 
     @application.before_request
     def remove_trailing_slash():

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -31,7 +31,7 @@ NO_ACCOUNT_MESSAGE = Markup("""Make sure you've entered the right email address 
 @main.route('/login', methods=["GET"])
 def render_login():
     next_url = request.args.get('next')
-    if current_user.is_authenticated() and not get_flashed_messages():
+    if current_user.is_authenticated and not get_flashed_messages():
         return redirect_logged_in_user(next_url)
 
     form = LoginForm()

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz"
   },
   "scripts": {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==0.10.1
-Flask-Login==0.2.11
+Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==0.10.1
-Flask-Login==0.2.11
+Flask-Login==0.4.1
 Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -13,9 +13,9 @@ class TestApplication(BaseApplicationTest):
         response = self.client.get('/not-found')
         assert 404 == response.status_code
 
-    @mock.patch('app.main.auth.current_user')
-    def test_503_renders_shared_error_template(self, current_user):
-        current_user.is_authenticated.side_effect = ServiceUnavailable()
+    @mock.patch('app.main.auth.get_errors_from_wtform')
+    def test_503_renders_shared_error_template(self, get_errors):
+        get_errors.side_effect = ServiceUnavailable()
         self.app.config['DEBUG'] = False
 
         res = self.client.get('/user/login')
@@ -41,9 +41,9 @@ class TestApplication(BaseApplicationTest):
         assert 200 == res.status_code
         assert 'DENY', res.headers['X-Frame-Options']
 
-    @mock.patch('app.main.auth.current_user')
-    def test_non_csrf_400(self, current_user):
-        current_user.is_authenticated.side_effect = BadRequest()
+    @mock.patch('app.main.auth.get_errors_from_wtform')
+    def test_non_csrf_400(self, get_errors):
+        get_errors.side_effect = BadRequest()
 
         res = self.client.get('/user/login')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,9 +515,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.7.0":
-  version "31.7.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#74459b8b9a5e8da35e967509ace77ceeedfd8e4a"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0":
+  version "31.8.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b30b2ad578d56e17889ce86a0004ee77db047751"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/euSnpBnN/65-update-flask-login

Changelog: https://github.com/maxcountryman/flask-login/blob/master/CHANGES

The only breaking change that affects the User FE is the `current_user.is_authenticated` method is now an attribute. As well as a check on the login page, we also use it to conditionally render certain links in the template header (hence the FE toolkit update).

Tested locally, it seems fine with other apps still on Flask-Login 0.2.x and the old templates.

We were also arbitrarily mocking `is_authenticated` in the error handling tests to make a view (any view!) raise an exception. Rather than fiddling about to make an mocked attribute have a side effect, I've just used a different function (`get_errors_from_wtform`) instead. We're not testing that view or those functions, just the error handling!