### PR TITLE
Add a Python version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-user-frontend/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-user-frontend?branch=master)
 [![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-user-frontend/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-user-frontend/requirements/?branch=master)
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 Frontend user application for the digital marketplace.
 


### PR DESCRIPTION
Adds a nifty visual indicator of what versions of Python we support

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support