### PR TITLE
password reset mechanism: handle inactive users more gracefully

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ class Config(object):
     NOTIFY_TEMPLATES = {
         "reset_password": "4ae02cdd-65fd-417f-8c24-61260229f9af",
         "change_password_alert": "1c4c0562-44aa-4ae4-ba61-e17c544df535",
+        "reset_password_inactive": "6c522c78-e4d2-488f-aa5f-6f42401ef2c5",
     }
 
     DEBUG = False


### PR DESCRIPTION
https://trello.com/c/ARkdAn0z

Depends on https://github.com/alphagov/digitalmarketplace-utils/pull/500

At token generation time, if the user turns out to be inactive, instead of sending a password reset token we send the user a message explaining that their account is disabled and what they can do about it.

~Still to do: decide on the content of this message, write the Notify template and paste its template id in to the `config`.~

~Edit: oh and write some functional tests.~