### PR TITLE
docker base image dependency: bump to 4.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:4.4.3
+FROM digitalmarketplace/base-frontend:4.5.4


### PR DESCRIPTION
Bumping this to the latest release so we get security updates etc.