### PR TITLE
Disallow admin-manager from using password reset

### DIFF
--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -52,7 +52,18 @@ def send_reset_password_email():
             user = User.from_json(user_json)
             notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
 
-            if user.active:  # specifically checking just .active, ignoring whether account is "locked"
+            if user.role in ("admin-manager"):
+                # if this user wants their password reset they'll have to come to us
+                current_app.logger.warning(
+                    "{code}: Password reset requested for {user_role} user '{email_hash}'",
+                    extra={
+                        "code": "login.reset-email.bad-role",
+                        "email_hash": hash_string(user.email_address),
+                        "user_role": user.role,
+                    }
+                )
+
+            elif user.active:  # specifically checking just .active, ignoring whether account is "locked"
                 token = generate_token(
                     {
                         "user": user.id

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -325,6 +325,22 @@ class TestResetPassword(BaseApplicationTest):
             reference='reset-password-inactive-8yc90Y2VvBnVHT5jVuSmeebxOCRJcnKicOe7VAsKu50=',
         )
 
+    @mock.patch("app.main.views.reset_password.DMNotifyClient.send_email", autospec=True)
+    def test_admin_manager_does_not_get_reset_email(self, send_email):
+        self.data_api_client.get_user.return_value = self.user(
+            123, "email@email.com", name="Eve", role="admin-manager",
+            supplier_id=None, supplier_name=None,
+        )
+        res = self.client.post(
+            "/user/reset-password",
+            data={"email_address": "email@email.com"}
+        )
+
+        # to prevent revealing email addresses for admins we still show the usual result
+        assert res.status_code == 302
+        self.assert_flashes("we'll send a link to reset the", expected_category='message')
+        send_email.assert_not_called()
+
 
 class TestChangePassword(BaseApplicationTest):
 


### PR DESCRIPTION
Trello: https://trello.com/c/lkytm0e1/604-disable-the-password-reset-mechanism-for-the-admin-manager