### PR TITLE
Move support email to app config

### DIFF
--- a/app/main/views/create_user.py
+++ b/app/main/views/create_user.py
@@ -16,7 +16,7 @@ from ... import data_api_client
 INVALID_TOKEN_MESSAGE = Markup(
     """The link you used to create an account is not valid. Check you’ve entered the correct link.
     If you still can’t create an account, email
-    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    <a href="mailto:{support_email}">{support_email}</a>
     """
 )
 
@@ -32,7 +32,7 @@ def create_user(encoded_token):
         )
         return render_template(
             "toolkit/errors/400.html",
-            error_message=INVALID_TOKEN_MESSAGE,
+            error_message=INVALID_TOKEN_MESSAGE.format(support_email=current_app.config['SUPPORT_EMAIL_ADDRESS']),
         ), 400
 
     role = token["role"]
@@ -45,6 +45,7 @@ def create_user(encoded_token):
         return render_template(
             "auth/create-user-error.html",
             error=None,
+            support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS'],
             role=role,
             token=None,
             user=None), 400
@@ -67,6 +68,7 @@ def create_user(encoded_token):
     return render_template(
         "auth/create-user-error.html",
         error=None,
+        support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS'],
         role=role,
         token=token,
         user=user), 400
@@ -83,7 +85,7 @@ def submit_create_user(encoded_token):
         )
         return render_template(
             "toolkit/errors/400.html",
-            error_message=INVALID_TOKEN_MESSAGE,
+            error_message=INVALID_TOKEN_MESSAGE.format(support_email=current_app.config['SUPPORT_EMAIL_ADDRESS']),
         ), 400
 
     role = token["role"]
@@ -96,6 +98,7 @@ def submit_create_user(encoded_token):
         return render_template(
             "auth/create-user-error.html",
             error=None,
+            support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS'],
             role=role,
             token=None,
             user=None), 400
@@ -137,6 +140,7 @@ def submit_create_user(encoded_token):
             return render_template(
                 "auth/create-user-error.html",
                 error=e.message,
+                support_email_address=current_app.config['SUPPORT_EMAIL_ADDRESS'],
                 role=role,
                 token=None), 400
         else:

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -18,8 +18,7 @@ from ... import data_api_client
 
 EMAIL_SENT_MESSAGE = Markup(
     """If the email address you've entered belongs to a Digital Marketplace account, we'll send a link to reset the
-    password. If you don’t receive this, email
-    <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+    password. If you don’t receive this, email <a href="mailto:{support_email}">{support_email}</a>.
     """
 )
 
@@ -125,7 +124,7 @@ def send_reset_password_email():
                 }
             )
 
-        flash(EMAIL_SENT_MESSAGE)
+        flash(EMAIL_SENT_MESSAGE.format(support_email=current_app.config['SUPPORT_EMAIL_ADDRESS']))
         return redirect(url_for('.request_password_reset'))
     else:
         return render_template("auth/request-password-reset.html",

--- a/app/templates/auth/create-user-error.html
+++ b/app/templates/auth/create-user-error.html
@@ -22,7 +22,7 @@
       <div class="explanation-list">
         <p class="lead">
           <a href="{{ url_for('external.create_buyer_account') }}">Create an account using a different email address</a> or email
-          <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if:
+          <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
         </p>
         <ul class="list-bullet">
           <li>
@@ -46,10 +46,10 @@
     The link you used to create an account may have expired.<br/>
     {% if role == 'buyer' %}
       Check you’ve entered the correct link or <a href="{{ url_for('external.create_buyer_account') }}">send a new one</a>.<br/>
-      If you still can’t create an account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+      If you still can’t create an account, email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>.
     {% elif role == 'supplier' %}
       Check you’ve entered the correct link or ask the person who invited you to send a new invitation.<br/>
-      If you still can’t create a contributor account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+      If you still can’t create a contributor account, email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a>.
     {% endif %}
   </p>
 
@@ -61,7 +61,7 @@
       <h1>Your account has been deactivated.</h1>
     </header>
     <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account.
+      Email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to reactivate your account.
     </p>
 
   {% elif user.locked %}
@@ -70,7 +70,7 @@
       <h1>Your account has been locked.</h1>
     </header>
     <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account.
+      Email <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to unlock your account.
     </p>
 
   {% elif role == 'buyer' and user.role == 'supplier' %}
@@ -80,7 +80,7 @@
     </header>
     <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
     <p>You can <a href="{{ url_for('external.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
-      <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to have your account
+      <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to have your account
       converted to a buyer account.</p>
     <p>
       Alternatively, <a href="{{ url_for('.render_login') }}">Log in</a> to your {{ user.supplier_name }} account.
@@ -96,7 +96,7 @@
     <br>
     <p>
       <a href="/login">Log in</a> to your {{ user.supplier_name }} account or email
-      <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to register your account with a different organisation.
+      <a href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> to register your account with a different organisation.
     </p>
 
   {% else %}

--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ class Config(object):
         "change_password_alert": "1c4c0562-44aa-4ae4-ba61-e17c544df535",
         "reset_password_inactive": "6c522c78-e4d2-488f-aa5f-6f42401ef2c5",
     }
+    SUPPORT_EMAIL_ADDRESS = "cloud_digital@crowncommercial.gov.uk"
 
     DEBUG = False
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -250,7 +250,7 @@ class BaseApplicationTest(object):
                 category, message = session['_flashes'][0]
             except KeyError:
                 raise AssertionError('nothing flashed')
-            assert expected_message in message
+            assert expected_message in message, message
             assert expected_category == category
 
     def assert_breadcrumbs(self, response, extra_breadcrumbs=None):

--- a/tests/main/views/test_create_user.py
+++ b/tests/main/views/test_create_user.py
@@ -9,8 +9,6 @@ from dmutils.email import generate_token
 
 from ...helpers import BaseApplicationTest
 
-from app.main.views.create_user import INVALID_TOKEN_MESSAGE
-
 
 class TestCreateUser(BaseApplicationTest):
 
@@ -65,7 +63,7 @@ class TestCreateUser(BaseApplicationTest):
             )
 
             assert res.status_code == 400
-            assert INVALID_TOKEN_MESSAGE in res.get_data(as_text=True)
+            assert "The link you used to create an account is not valid." in res.get_data(as_text=True)
 
     def test_invalid_token_contents_500s(self):
         token = generate_token(
@@ -349,7 +347,7 @@ class TestSubmitCreateUser(BaseApplicationTest):
 
             assert res.status_code == 400
             assert 'Bad request - Digital Marketplace' in res.get_data(as_text=True)
-            assert INVALID_TOKEN_MESSAGE in res.get_data(as_text=True)
+            assert "The link you used to create an account is not valid." in res.get_data(as_text=True)
 
     def test_should_be_a_bad_request_if_token_expired(self):
         for role in self.user_roles:

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -79,7 +79,7 @@ class TestResetPassword(BaseApplicationTest):
         }, follow_redirects=True)
         assert res.status_code == 200
         content = self.strip_all_whitespace(res.get_data(as_text=True))
-        assert self.strip_all_whitespace(reset_password.EMAIL_SENT_MESSAGE) in content
+        assert self.strip_all_whitespace("we'll send a link to reset the password") in content
 
     @mock.patch('app.main.views.reset_password.DMNotifyClient.send_email')
     def test_should_strip_whitespace_surrounding_reset_password_email_address_field(self, send_email):
@@ -316,7 +316,8 @@ class TestResetPassword(BaseApplicationTest):
         )
 
         assert res.status_code == 302
-        self.assert_flashes(reset_password.EMAIL_SENT_MESSAGE, expected_category='message')
+        # Asserting the whole flash message is a bit messy due to line breaks
+        self.assert_flashes("we'll send a link to reset the", expected_category='message')
         send_email.assert_called_once_with(
             mock.ANY,  # self
             "email@email.com",


### PR DESCRIPTION
https://trello.com/c/3om47rfx/601-update-remaining-instances-of-enquiriesdigitalmarketplaceservicegovuk-to-the-new-support-address

Centralises the support email rather than hardcoding it in:
- create user templates/flash messages
- reset password templates/flash messages (see below)

![reset-password-help-emai](https://user-images.githubusercontent.com/3492540/61304906-cff60d80-a7e1-11e9-9791-d7f53c20ac00.png)
