### PR TITLE
send_reset_password_email: fix check of user.role being "admin-manager" 

### DIFF
--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -52,7 +52,7 @@ def send_reset_password_email():
             user = User.from_json(user_json)
             notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
 
-            if user.role in ("admin-manager"):
+            if user.role in ("admin-manager",):
                 # if this user wants their password reset they'll have to come to us
                 current_app.logger.warning(
                     "{code}: Password reset requested for {user_role} user '{email_hash}'",

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -262,8 +262,20 @@ class TestResetPassword(BaseApplicationTest):
         assert reset_password.EXPIRED_PASSWORD_RESET_TOKEN_MESSAGE in error_elements[0].text_content()
         assert self.data_api_client.update_user_password.called is False
 
+    @pytest.mark.parametrize("user_role", (
+        "admin",
+        "admin-ccs-category",
+        "admin-ccs-sourcing",
+        "admin-ccs-data-controller",
+        "admin-framework-manager",
+        "buyer",
+        "supplier",
+    ))
     @mock.patch('app.main.views.reset_password.DMNotifyClient.send_email', autospec=True)
-    def test_should_call_send_email_with_correct_params(self, send_email):
+    def test_should_call_send_email_with_correct_params(self, send_email, user_role):
+        self.data_api_client.get_user.return_value = self.user(
+            123, "email@email.com", 1234, "Ahoy", name="Bob", role=user_role,
+        )
         res = self.client.post(
             '/user/reset-password',
             data={'email_address': 'email@email.com'}


### PR DESCRIPTION
https://trello.com/c/o7nrGSfH

Without a comma this is just interpreted as a set of ignorable brackets.

Also improved the tests around this. This is a perfect example of why "one test, one feature" doesn't cut it.