### PR TITLE
Allow visiting `/users/logout` with a GET request

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -79,7 +79,12 @@ def process_login():
             next=next_url), 400
 
 
-@main.route('/logout', methods=["POST"])
+# We allow logging out via GET request so that we can have a simple link in the
+# site header. We would prefer to be able to have a degree of protection
+# against inadvertent/malicious logout requests without the user knowing, which
+# is why we have used POST previously, but our site header design needs work
+# before that can happen.
+@main.route('/logout', methods=["GET", "POST"])
 def logout():
     session.clear()
     logout_user()

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -186,6 +186,14 @@ class TestLogin(BaseApplicationTest):
         with self.client.session_transaction() as session:
             assert session.get('company_name') is None
 
+    @mock.patch("app.main.views.auth.logout_user")
+    def test_visiting_logout_should_logout(self, logout_user):
+        self.login_as_supplier()
+        res = self.client.get('/user/logout')
+        assert logout_user.called
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/user/login'
+
     def test_should_return_a_403_for_invalid_login(self):
         self.data_api_client.authenticate_user.return_value = None
 


### PR DESCRIPTION
## Summary

We might want to be able to create a link to logout a user using the `<a>` HTML tag. I've created this PR as a strawman that we can discuss.

## Details

In our current frontend apps we use a form to ask the browser to make a POST request to the logout url. This has some advantages on the backend (it's clear that the request is destructive, we can include a CSRF token), but on the frontend this causes issues with the log out button.

In the current admin frontend the focus state of a form differs visually from the focus state of a link.

![In the current admin frontend the focus state of a form differs visually from the focus state of a link](https://user-images.githubusercontent.com/503614/64872440-1f6c8480-d63f-11e9-8547-3b22b204a405.gif)

With the GOV.UK Frontend, this problem is exacerbated as currently the header component does not support arbitrary HTML, and the form styles are designed for multiple inputs, not just one button.

![In the admin frontend with the GOV.UK Frontend header focusing on the log out button using the keyboard requires pressing tab multiple times to move through the form](https://user-images.githubusercontent.com/3441519/64864488-1d022e80-d62f-11e9-9b8a-3f877438adf2.gif)

These issues with the focus state might not be easy to fix if we continue to use a form for the log out button; ideally the button should be a simple link. However, a HTML link can only make a GET request (unless JavaScript is used), so we have to allow GET requests to the `logout` route.

## Possible issues

There is some suggestion that having a link to a log out endpoint might cause users to be logged out by aggressive browser pre-caching (see Stack Overflow issues [1](https://stackoverflow.com/a/14587231) [2](https://stackoverflow.com/a/15098437)), however I have tested this locally with the admin frontend and there did not seem to be any issue logging in and staying logged in.