### PR TITLE
Remove password used in tests

### DIFF
--- a/app/data/password_blacklist/10-million-password-list-top-100000.txt
+++ b/app/data/password_blacklist/10-million-password-list-top-100000.txt
@@ -31870,7 +31870,6 @@ pericles
 people1
 payroll
 paul1
-password1234
 passer
 PASS
 parrish


### PR DESCRIPTION
This password is used in some tests and consequently was causing failures.