### PR TITLE
Password reset sends sandbox email for nonexistent accounts

### DIFF
--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -94,7 +94,7 @@ def send_reset_password_email():
                     ), 503
 
                 current_app.logger.info(
-                    "{code}: Sending password reset email for email_hash {email_hash}",
+                    "{code}: Sent password reset email for email_hash {email_hash}",
                     extra={
                         'email_hash': hash_string(user.email_address),
                         'code': 'login.reset-email.sent'
@@ -120,7 +120,7 @@ def send_reset_password_email():
                     ), 503
 
                 current_app.logger.warning(
-                    "{code}: Sending password (non-)reset email for inactive user email_hash {email_hash}",
+                    "{code}: Sent password (non-)reset email for inactive user email_hash {email_hash}",
                     extra={
                         'email_hash': hash_string(user.email_address),
                         'code': 'login.reset-email-inactive.sent',
@@ -149,7 +149,7 @@ def send_reset_password_email():
                 ), 503
 
             current_app.logger.info(
-                "{code}: Sending password (non-)reset email for invalid user email_hash {email_hash}",
+                "{code}: Sent password (non-)reset email for invalid user email_hash {email_hash}",
                 extra={
                     'email_hash': hash_string(email_address),
                     'code': 'login.reset-email.invalid-email'

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -140,7 +140,7 @@ def send_reset_password_email():
                 log_email_error(
                     exc,
                     "Password reset (non-existent user)",
-                    "login.reset-email.notify-error",
+                    "login.reset-email-nonexistent.notify-error",
                     email_address,  # Hashed by the helper function
                 )
                 return render_template(

--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -30,6 +30,7 @@ EXPIRED_PASSWORD_RESET_TOKEN_MESSAGE = Markup(
 
 PASSWORD_UPDATED_MESSAGE = "You have successfully changed your password."
 PASSWORD_NOT_UPDATED_MESSAGE = "Could not update password due to an error."
+NOTIFY_SANDBOX_ADDRESS = "simulate-delivered@notifications.service.gov.uk"
 
 
 @main.route('/reset-password', methods=["GET"])
@@ -47,11 +48,10 @@ def send_reset_password_email():
     if form.validate_on_submit():
         email_address = form.email_address.data
         user_json = data_api_client.get_user(email_address=email_address)
+        notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
 
         if user_json is not None:
             user = User.from_json(user_json)
-            notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
-
             if user.role in ("admin-manager",):
                 # if this user wants their password reset they'll have to come to us
                 current_app.logger.warning(
@@ -127,8 +127,29 @@ def send_reset_password_email():
                     }
                 )
         else:
+            # Send a email to the Notify sandbox using the 'inactive' template, to mitigate any timing attacks (where
+            # a user's existence could be determined by the response time of this view). Any errors are also handled
+            # in the same way as for inactive users.
+            try:
+                notify_client.send_email(
+                    NOTIFY_SANDBOX_ADDRESS,
+                    template_name_or_id=current_app.config['NOTIFY_TEMPLATES']['reset_password_inactive'],
+                    reference='reset-password-nonexistent-user-{}'.format(hash_string(email_address)),
+                )
+            except EmailError as exc:
+                log_email_error(
+                    exc,
+                    "Password reset (non-existent user)",
+                    "login.reset-email.notify-error",
+                    email_address,  # Hashed by the helper function
+                )
+                return render_template(
+                    'toolkit/errors/500.html',
+                    error_message="Failed to send password reset.",
+                ), 503
+
             current_app.logger.info(
-                "{code}: Password reset request for invalid email_hash {email_hash}",
+                "{code}: Sending password (non-)reset email for invalid user email_hash {email_hash}",
                 extra={
                     'email_hash': hash_string(email_address),
                     'code': 'login.reset-email.invalid-email'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,5 @@ mock==3.0.5
 pytest==4.6.3
 pytest-cov==2.7.1
 watchdog==0.9.0
+
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.5.1#egg=digitalmarketplace-test-utils==2.5.1

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -112,7 +112,7 @@ class TestSendResetPasswordEmail(BaseApplicationTest):
             template_name_or_id=current_app_mock.config['NOTIFY_TEMPLATES']['reset_password_inactive']
         )]
         assert current_app_mock.logger.info.call_args_list == [mock.call(
-            '{code}: Sending password (non-)reset email for invalid user email_hash {email_hash}',
+            '{code}: Sent password (non-)reset email for invalid user email_hash {email_hash}',
             extra={
                 'email_hash': self.expected_email_hash,
                 'code': 'login.reset-email.invalid-email'


### PR DESCRIPTION
Trello: https://trello.com/c/PTzPDEqq/1166-address-user-enumeration-forgot-pw-function-vulnerability

Addresses the scenario where an attacker could determine the existence of an account by looking at the response time from the password reset view. To mitigate this, the view should do roughly the same actions for a non-existent user as for an existing inactive user. Local timing testing is always going to be a bit unreliable in terms of network requests so I'd like to see how this does on Preview before releasing.

Agreed with the Notify team that the sandbox email address is suitable for this usecase.

I also tidied up the tests for this view, as it was hard to tell what paths had coverage.