### PR TITLE
43-create-a-base-page-for-the-apps

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,0 +1,4 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+// Insert line for each component module import
+

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Change password – Digital Marketplace{% endblock %}
 

--- a/app/templates/auth/create-user-error.html
+++ b/app/templates/auth/create-user-error.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
   {% if role == 'supplier' %}Create contributor account{% else %}Create account error{% endif %} - Digital Marketplace

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
   Create account – Digital Marketplace

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Log in – Digital Marketplace{% endblock %}
 

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}User reserch notification – Digital Marketplace{% endblock %}
 


### PR DESCRIPTION
https://trello.com/c/PpFz5qRc/43-create-a-base-page-for-the-apps

The work to move to govuk-frontend will be easier if we have a base page in each app in which to import macros.

GOVUK Frontend may solve this down the road
https://github.com/alphagov/govuk-frontend/issues/1278

It seems from research (Googling and GOV Pay) for now this is the accepted pattern