### PR TITLE
switch to using digitalmarketplace-govuk-frontend for breadcrumbs, standardize trailing breadcrumb element

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -2,4 +2,20 @@
 
 // Insert line for each component module import
 
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
+
+{# override content block to add a beforeContent block like the one in govuk-frontend template #}
+{% block content %}
+  {% block top_header %}{% endblock %}
+  <div id="wrapper">
+    {% block beforeContent %}
+      {% block breadcrumb %}{% endblock %}
+    {% endblock %}
+    <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
+      {% block main_content %}
+      {% endblock %}
+    </main>
+  </div>
+{% endblock %}

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -3,20 +3,19 @@
 {% block page_title %}Change password – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-      {
-        "link": "/",
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": dashboard_url,
-        "label": "Your account"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  {{ govukBreadcrumbs({"items": [
+    {
+      "text": "Digital Marketplace",
+      "href": "/",
+    },
+    {
+      "text": "Your account",
+      "href": dashboard_url,
+    },
+    {
+      "text": "Change your password",
+    },
+  ]}) }}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -3,19 +3,15 @@
 {% block page_title %}Log in – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-      {
-        "link": "/",
-        "label": "Digital Marketplace"
-      },
-      {
-        "label": "Login"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  {{ govukBreadcrumbs({"items": [
+    {
+      "text": "Digital Marketplace",
+      "href": "/",
+    },
+    {
+      "text": "Login",
+    },
+  ]}) }}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -3,23 +3,19 @@
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-      {
-        "link": "/",
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": "/user/login",
-        "label": "Login"
-      },
-      {
-        "label": "Reset password"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  {{ govukBreadcrumbs({"items": [
+    {
+      "text": "Digital Marketplace",
+      "href": "/",
+    },
+    {
+      "text": "Login",
+      "href": "/user/login",
+    },
+    {
+      "text": "Reset password",
+    },
+  ]}) }}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -3,19 +3,15 @@
 {% block page_title %}Reset password – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-      {
-        "link": "/",
-        "label": "Digital Marketplace"
-      },
-      {
-        "label": "Reset password"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  {{ govukBreadcrumbs({"items": [
+    {
+      "text": "Digital Marketplace",
+      "href": "/",
+    },
+    {
+      "text": "Reset password",
+    },
+  ]}) }}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -3,20 +3,19 @@
 {% block page_title %}User reserch notification – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
-      {
-        "link": "/",
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": dashboard_url,
-        "label": "Your account"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
+  {{ govukBreadcrumbs({"items": [
+    {
+      "text": "Digital Marketplace",
+      "href": "/",
+    },
+    {
+      "text": "Your account",
+      "href": dashboard_url,
+    },
+    {
+      "text": "User research mailing list",
+    },
+  ]}) }}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -13,7 +13,7 @@
       "href": dashboard_url,
     },
     {
-      "text": "User research mailing list",
+      "text": "User research mailing list preferences",
     },
   ]}) }}
 {% endblock %}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -255,7 +255,7 @@ class BaseApplicationTest(object):
 
     def assert_breadcrumbs(self, response, extra_breadcrumbs=None):
         breadcrumbs = html.fromstring(response.get_data(as_text=True)).xpath(
-            '//*[@id="global-breadcrumb"]/nav/ol/li'
+            '//*[@class="govuk-breadcrumbs"]/ol/li'
         )
 
         breadcrumbs_we_expect = [('Digital Marketplace', '/')]
@@ -265,8 +265,13 @@ class BaseApplicationTest(object):
         assert len(breadcrumbs) == len(breadcrumbs_we_expect)
 
         for index, link in enumerate(breadcrumbs_we_expect):
-            assert breadcrumbs[index].find('a').text_content().strip() == link[0]
-            assert breadcrumbs[index].find('a').get('href').strip() == link[1]
+            if link[1] is None:
+                # a non-link breadcrumb
+                assert breadcrumbs[index].xpath("normalize-space(string())") == link[0]
+                assert not breadcrumbs[index].find("a")
+            else:
+                assert breadcrumbs[index].find('a').xpath("normalize-space(string())") == link[0]
+                assert breadcrumbs[index].find('a').get('href').strip() == link[1]
 
 
 class MockMatcher(object):

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -492,7 +492,7 @@ class TestChangePassword(BaseApplicationTest):
         assert response.status_code == 200
         document = html.fromstring(response.get_data(as_text=True))
 
-        self.assert_breadcrumbs(response, [("Your account", redirect_url)])
+        self.assert_breadcrumbs(response, [("Your account", redirect_url), ("Change your password", None)])
 
         form_labels = document.xpath('//form//label/text()')
 


### PR DESCRIPTION
https://trello.com/c/vcjVUo8x

In places where we didn't previously have a trailing breadcrumb element representing the current page I added one, mostly with the exact heading of the page but in some places using a bit of artistic license to make it a bit simpler (see user research mailing list page).

![Spectacle nS6501](https://user-images.githubusercontent.com/807447/67092112-51c15280-f1a6-11e9-997e-2cf45bb752d0.png)
