### PR TITLE
Bumps jquery from 1.12 to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1269,6 +1269,70 @@
               }
             }
           }
+        },
+        "gulp-jasmine-phantom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-jasmine-phantom/-/gulp-jasmine-phantom-3.0.0.tgz",
+          "integrity": "sha1-jgsrsi5x1AVqIumoGyFmGRhiU5Y=",
+          "requires": {
+            "glob": "^4.0.6",
+            "gulp-util": "^3.0.0",
+            "handlebars": "^2.0.0",
+            "jasmine": "github:dflynn15/jasmine-npm",
+            "lodash": "^4.3.0",
+            "through2": "^0.6.1"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^2.0.1",
+                "once": "^1.3.0"
+              }
+            }
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
         }
       }
     },
@@ -4077,9 +4141,9 @@
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg=="
     },
     "jquery": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.0.tgz",
-      "integrity": "sha1-RGU75OPkYosQa/IUHf0Q+8pgIe8="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
     "hogan.js": "3.0.2",
-    "jquery": "1.12.0"
+    "jquery": "3.4.1"
   },
   "scripts": {
     "frontend-build:development": "gulp build:development",


### PR DESCRIPTION
https://trello.com/c/aQbqH2uC/1196-vulnerability-fix-weekly-tracking

Addressing https://app.snyk.io/vuln/npm:jquery:20150627 and https://app.snyk.io/vuln/SNYK-JS-JQUERY-174006

The User FE only uses jquery in a couple of unit tests for the analytics functions. If those tests are later centralised in the FE toolkit, we can remove this dependency.
