### PR TITLE
[Fix] Remove unused live-search.js from User FE

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,7 +9,6 @@
 //= require ../../../node_modules/hogan.js/web/builds/3.0.2/hogan-3.0.2.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/support.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/live-search.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/clear-filters.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js


### PR DESCRIPTION
The AJAX calls in this module were giving Javascript errors after we [bumped jquery to v3](https://github.com/alphagov/digitalmarketplace-user-frontend/pull/168), causing our Capybara tests to fail:

```
https://www.preview.marketplace.team/user/static/javascripts/application.js?28b93c55c2e834a461825f454eae7148:1 in handle (Capybara::Poltergeist::JavascriptError)
```