### PR TITLE
1222-decide-whether-to-decrease-the-number-of-failed-login-attempts-b…

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -24,7 +24,7 @@ from ... import data_api_client
 
 
 NO_ACCOUNT_MESSAGE = Markup("""Make sure you've entered the right email address and password. Accounts
-    are locked after 10 failed attempts. If you’ve forgotten your password you can reset it by clicking
+    are locked after 5 failed attempts. If you’ve forgotten your password you can reset it by clicking
     ‘Forgotten password’.""")
 
 


### PR DESCRIPTION
…efore-account-lock-down

https://trello.com/c/Yc5XGfjI/1222-decide-whether-to-decrease-the-number-of-failed-login-attempts-before-account-lock-down

Decision made to drop this limit to 5 as per guidance change:
https://github.com/alphagov/govuk-design-system/pull/1058

Corresponding API PR must go out at the same time.