### PR TITLE
switch grid elements to digitalmarketplace-govuk-frontend's classes

### DIFF
--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -25,8 +25,8 @@
 
 <form autocomplete="off" action="{{ url_for('.change_password') }}" method="POST">
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
             {{ form.hidden_tag() }}
 
             {% with question = form.old_password.label,

--- a/app/templates/auth/create-user-error.html
+++ b/app/templates/auth/create-user-error.html
@@ -8,8 +8,8 @@
 
 {% if error == 'invalid_buyer_domain' %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds error-page">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds error-page">
       <h1 class="govuk-heading-l">You must use a public sector email address</h1>
       <p class="govuk-body">
         You must be employed by, or represent, a public sector organisation to create a buyer account.

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -22,8 +22,8 @@
 
     <form autocomplete="off" action="{{ url_for('.submit_create_user', encoded_token=token) }}" method="POST" id="createUserForm">
 
-        <div class="grid-row">
-            <div class="column-two-thirds">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
                 {{ form.hidden_tag() }}
   
                 {% with question = form.name.label,

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -23,8 +23,8 @@
 <h1 class="govuk-heading-xl">Log in to the Digital Marketplace</h1>
 
 <form autocomplete="off" action="{{ url_for('.process_login', next=next) }}" method="POST">
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
 
             {{ form.hidden_tag() }}
   

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -32,8 +32,8 @@
 </p>
 
 <form autocomplete="off" action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
 
             {{ form.hidden_tag() }}
 

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -27,8 +27,8 @@
 
 <form autocomplete="off" action="{{ url_for('.update_password', token=token) }}" method="POST">
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
             {{ form.hidden_tag() }}
             
             {% with question = form.password.label,

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -20,10 +20,10 @@
 
 {% block main_content %}
 
-<div class="grid-row notification-user-research">
+<div class="govuk-grid-row notification-user-research">
   {% include 'toolkit/forms/validation.html' %}
 
-  <div class="column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
     {% if form.user_research_opt_in.data %}
       Unsubscribe from the user research mailing list


### PR DESCRIPTION
https://trello.com/c/pLpLtMx1

This also quietly slips in a fix for a mistake from a previous merge, leaving us with mismatched tags and broken layout on the user research consent page. Al and I also agreed that the content there should be turned into a _bulleted_ list.

Otherwise the grid changes seem to make little difference.