### PR TITLE
Copy fonts to static folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -234,7 +234,7 @@ gulp.task(
   copyFactory(
     'fonts from the GOVUK frontend assets',
     govukFrontendFontsFolder,
-    assetsFolder + '/fonts'
+    staticFolder + '/fonts'
   )
 )
 


### PR DESCRIPTION
Fixing a bug with the build process where fonts were not being copied to
the correct path. This is not an issue at the moment because we are still
using govuk_template but once we migrate to govuk-frontend then it would
become a problem

Ticket: https://trello.com/c/HDc1fOJp