### PR TITLE
replace page_title block with pageTitle

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -5,6 +5,10 @@
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 
+
+{# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
+{% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}
+
 {# override content block to add a beforeContent block like the one in govuk-frontend template #}
 {% block content %}
   {% block top_header %}{% endblock %}

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Change password – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Change password – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({"items": [

--- a/app/templates/auth/create-user-error.html
+++ b/app/templates/auth/create-user-error.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   {% if role == 'supplier' %}Create contributor account{% else %}Create account error{% endif %} - Digital Marketplace
 {% endblock %}
 

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Create account – Digital Marketplace
 {% endblock %}
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Log in – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Log in – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({"items": [

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Reset password – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Reset password – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({"items": [

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Reset password – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Reset password – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({"items": [

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}User reserch notification – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  User reserch notification – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {{ govukBreadcrumbs({"items": [


### PR DESCRIPTION
As part of migrating us off govuk_template and on to govuk frontend template
we need to be mindful of what blocks govuk frontend uses. govuk frontend
template uses pageTitle so instead of adding this commit to that work it
can be done as a separate commit and then once we come to replace govuk_template
we can just remove the two lines of code in `_base_page` which we added
in this commit.

Ticket: https://trello.com/c/R7sypvUC