### PR TITLE
replace main_content block with mainContent

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -18,7 +18,10 @@
     {% endblock %}
     <main id="content" role="main">
       {% include "toolkit/flash_messages.html" %}
+      {# TODO: Remove this block when we start removing govuk_template but be sure #}
+      {#       To keep the inner block mainContent otherwise no content will be rendered #}
       {% block main_content %}
+        {% block mainContent %}{% endblock %}
       {% endblock %}
     </main>
   </div>

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -20,7 +20,7 @@
   ]}) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% include 'toolkit/forms/validation.html' %}
 
   <h1 class="govuk-heading-xl">Change your password</h1>

--- a/app/templates/auth/create-user-error.html
+++ b/app/templates/auth/create-user-error.html
@@ -4,7 +4,7 @@
   {% if role == 'supplier' %}Create contributor account{% else %}Create account error{% endif %} - Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% if error == 'invalid_buyer_domain' %}
 

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -4,7 +4,7 @@
   Create account – Digital Marketplace
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% with lede = "There was a problem with the details you gave for:" %}
     {% include 'toolkit/forms/validation.html' %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -16,7 +16,7 @@
   ]}) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% with lede = "There was a problem with the details you gave for:" %}
     {% include 'toolkit/forms/validation.html' %}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -20,7 +20,7 @@
   ]}) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   {% with lede = "There was a problem with the details you gave for:" %}
     {% include 'toolkit/forms/validation.html' %}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -16,7 +16,7 @@
   ]}) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
   {% with lede = "There was a problem with the details you gave for:" %}
     {% include "toolkit/forms/validation.html" %}
   {% endwith %}

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -20,7 +20,7 @@
   ]}) }}
 {% endblock %}
 
-{% block main_content %}
+{% block mainContent %}
 
   <div class="govuk-grid-row notification-user-research">
     {% include 'toolkit/forms/validation.html' %}


### PR DESCRIPTION
As part of migrating us off govuk_template and on to govuk frontend template
we need to be mindful about what blocks govuk frontend uses. govuk frontend
template uses content block so instead of adding this commit to that work it
can be done as a separate commit and then once we come to replace govuk_template
we can just remove the `main_content` block of code and leave mainContent block in `_base_page`.
We will need to output flash messaging inside the content block so we cannot just use govuk-frontend template's `content` block to render our page.

Ticket: https://trello.com/c/sTPVOIu2