### PR TITLE
Updates digitalmarketplace-govuk-frontend to 0.2.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,9 +58,12 @@ class Config(object):
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
+        digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
+
         template_folders = [
             os.path.join(repo_root, 'app', 'templates'),
-            os.path.join(repo_root, 'node_modules', 'digitalmarketplace-govuk-frontend', 'govuk-frontend'),
+            os.path.join(digitalmarketplace_govuk_frontend, 'digitalmarketplace', 'templates'),
+            os.path.join(digitalmarketplace_govuk_frontend, 'govuk-frontend'),
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,9 +1337,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.0.tgz",
-      "integrity": "sha512-sELMElO6SS4MuPYHYEDr0+ZhIg2ZKr2TzWrxm52lcZKuMmgJ2otq3x1aezcZbj7ZXpwdNtoTOrvlTH1xy08bkQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.2.1.tgz",
+      "integrity": "sha512-rrXK/GEFiHDsXv2IP0d8lOYfW1yDgh5OX/lOl38gn/uAmHlqNdzhpZws6Ioro7IoG593CoSl5aWewuuUHBdgYA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
-    "digitalmarketplace-govuk-frontend": "^0.2.0",
+    "digitalmarketplace-govuk-frontend": "^0.2.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",


### PR DESCRIPTION
Updates digitalmarketplace-govuk-frontend to 0.2.1 which fixes and issue with error pages.

## Before
![Screenshot 2019-11-05 at 14 05 54](https://user-images.githubusercontent.com/3441519/68215162-ace0ab00-ffd6-11e9-9ce1-96fd9898ab6a.png)

## After
![Screenshot 2019-11-05 at 14 08 57](https://user-images.githubusercontent.com/3441519/68215173-b10cc880-ffd6-11e9-9efe-625b8c445b37.png)

Ticket https://trello.com/c/T9hBnYM5