### PR TITLE
Removes dmspeak import from application.scss

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -15,7 +15,6 @@ $path: "/user/static/images/";
 // Digital Marketplace Front-end toolkit shared styles between multiple apps
 @import "toolkit/shared_scss/_reset.scss";
 @import "toolkit/shared_scss/_lists.scss";
-@import "toolkit/shared_scss/_dmspeak.scss";
 
 // Digital Marketplace Front-end toolkit styles (only import the files you need)
 @import "toolkit/_breadcrumb.scss";


### PR DESCRIPTION
We are no longer using the dmspeak classes so we should remove the import. 