### PR TITLE
Remove error-page styling

### DIFF
--- a/app/assets/scss/_error-pages.scss
+++ b/app/assets/scss/_error-pages.scss
@@ -1,3 +1,0 @@
-.error-page {
-  @extend .dmspeak;
-}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -44,7 +44,6 @@ $govuk-compatibility-govukelements: true;
 @import "_footer.scss";
 @import "_text.scss";
 @import "_secondary-action-link.scss";
-@import "_error-pages.scss";
 
 // Overrides
 @import "overrides/_notification-banner";


### PR DESCRIPTION
The application is now using digitalmarketplace-govuk-frontend error page
template. We have also removed dmspeak so this would not output anything.