### PR TITLE
Replace Validation component with GOV.UK Error Summary

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/clear-filters.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -4,7 +4,7 @@
 
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
-
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
 {% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}
@@ -18,6 +18,14 @@
     {% endblock %}
     <main id="content" role="main">
       {% include "toolkit/flash_messages.html" %}
+      {% block errorSummary %}
+        {% if errors %}
+          {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": errors.values()
+        }) }}
+        {% endif %}
+      {% endblock %}
       {# TODO: Remove this block when we start removing govuk_template but be sure #}
       {#       To keep the inner block mainContent otherwise no content will be rendered #}
       {% block main_content %}

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -21,7 +21,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% include 'toolkit/forms/validation.html' %}
 
   <h1 class="govuk-heading-xl">Change your password</h1>
 

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -5,11 +5,6 @@
 {% endblock %}
 
 {% block mainContent %}
-
-  {% with lede = "There was a problem with the details you gave for:" %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endwith %}
-
   {% set headings = {
       'buyer': 'Create a new Digital Marketplace account',
       'supplier': "Add your name and create a password"

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -17,11 +17,6 @@
 {% endblock %}
 
 {% block mainContent %}
-
-  {% with lede = "There was a problem with the details you gave for:" %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endwith %}
-
   <h1 class="govuk-heading-xl">Log in to the Digital Marketplace</h1>
 
   <form autocomplete="off" action="{{ url_for('.process_login', next=next) }}" method="POST">

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -21,11 +21,6 @@
 {% endblock %}
 
 {% block mainContent %}
-
-  {% with lede = "There was a problem with the details you gave for:" %}
-    {% include 'toolkit/forms/validation.html' %}
-  {% endwith %}
-
   <h1 class="govuk-heading-xl">Reset password</h1>
 
   <p class="govuk-body-l">

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -17,9 +17,6 @@
 {% endblock %}
 
 {% block mainContent %}
-  {% with lede = "There was a problem with the details you gave for:" %}
-    {% include "toolkit/forms/validation.html" %}
-  {% endwith %}
 
   <h1 class="govuk-heading-xl">Reset password</h1>
 

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -23,7 +23,6 @@
 {% block mainContent %}
 
   <div class="govuk-grid-row notification-user-research">
-    {% include 'toolkit/forms/validation.html' %}
 
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.1.0#egg=digitalmarketplace-utils==50.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.1.0#egg=digitalmarketplace-utils==50.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha
@@ -15,8 +15,8 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.16
-botocore==1.13.16
+boto3==1.10.22
+botocore==1.13.22
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4


### PR DESCRIPTION
Requires https://github.com/alphagov/digitalmarketplace-utils/pull/543 to be merged and for this repo to be updated to use the changes.

Ticket: https://trello.com/c/jy1qTEQN/132-replace-validation-banner-with-govuk-frontend-error-summary-component-in-user-frontend