### PR TITLE
Update textboxes to use GOV.UK Frontend text input component

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -47,6 +47,7 @@ $govuk-compatibility-govukelements: true;
 // Overrides
 @import "overrides/_notification-banner";
 @import "overrides/_page_headings";
+@import "overrides/_govuk-label";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -27,7 +27,6 @@ $path: "/user/static/images/";
 @import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_questions.scss";
 @import "toolkit/forms/_textboxes.scss";
-@import "toolkit/forms/_validation.scss";
 @import "toolkit/forms/_selection-buttons.scss";
 @import "toolkit/_user-research-consent-banner.scss";
 

--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -1,0 +1,15 @@
+// We want to ensure that govuk-label components are consistent with existing
+// labels. To do this we change the default label class to be styled like a
+// medium heading. This style was copied from
+// https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/components/label/_label.scss#L27-L30
+//
+// TODO: Remove/move this to digitalmarketplace-govuk-frontend when ready
+
+.govuk-label {
+  @include govuk-text-colour;
+  @include govuk-font($size: 24, $weight: bold);
+
+  display: block;
+
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -5,6 +5,8 @@
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "components/input/macro.njk" import govukInput %}
+
 
 {# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
 {% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}

--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -29,36 +29,48 @@
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
 
-        {% with question = form.old_password.label,
-                name = "old_password",
-                error = errors.get('old_password', {}).get('message'),
-                value = form.old_password.data,
-                type = "password",
-                autocomplete = "off"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.old_password.label.text,
+          },
+          "errorMessage": errors.old_password.errorMessage,
+          "id": "input-old_password",
+          "type": "password",
+          "name": "old_password",
+          "value": form.old_password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
-        {% with question = form.password.label,
-                name = "password",
-                error = errors.get('password', {}).get('message'),
-                hint = form.password.hint,
-                value = form.password.data,
-                type = "password",
-                autocomplete = "off"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.password.label.text,
+          },
+          "errorMessage": errors.password.errorMessage,
+          "id": "input-password",
+          "type": "password",
+          "name": "password",
+          "value": form.password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
-        {% with question = form.confirm_password.label,
-                name = "confirm_password",
-                error = errors.get('confirm_password', {}).get('message'),
-                value = form.confirm_password.data,
-                type = "password",
-                autocomplete = "off"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+
+        {{ govukInput({
+          "label": {
+            "text": form.confirm_password.label.text,
+          },
+          "errorMessage": errors.confirm_password.errorMessage,
+          "id": "input-confirm_password",
+          "type": "password",
+          "name": "confirm_password",
+          "value": form.confirm_password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
         {{ govukButton({
           "text": "Save changes"

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -19,35 +19,51 @@
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
 
-        {% with question = form.name.label,
-                name = "name",
-                error = errors.get('name', {}).get('message'),
-                value = form.name.data,
-                autocomplete = "off"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.name.label.text,
+          },
+          "errorMessage": errors.name.errorMessage,
+          "id": "input-name",
+          "name": "name",
+          "value": form.name.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
+
 
         {% if role == 'buyer' %}
-          {% with question = form.phone_number.label,
-                  name = "phone_number",
-                  error = errors.get('phone_number', {}).get('message'),
-                  hint = form.phone_number.hint,
-                  value = form.phone_number.data,
-                  autocomplete = "off"
-          %}
-            {% include "toolkit/forms/textbox.html" %}
-          {% endwith %}
+          {{ govukInput({
+            "label": {
+              "text": form.phone_number.label.text,
+            },
+            "hint": {
+              "text": form.phone_number.hint,
+            },
+            "errorMessage": errors.phone_number.errorMessage,
+            "id": "input-phone_number",
+            "name": "phone_number",
+            "value": form.phone_number.data,
+            "attributes": {
+              "autocomplete": "off",
+            },
+          }) }}
         {% endif %}
 
-        {% with question = form.password.label,
-                name = "password",
-                error = errors.get('password', {}).get('message'),
-                value = form.password.data,
-                type = "password"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.password.label.text,
+          },
+          "errorMessage": errors.password.errorMessage,
+          "id": "input-password",
+          "type": "password",
+          "name": "password",
+          "value": form.password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
         {{ govukButton({
           "text": "Create account"

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -33,10 +33,12 @@
           },
           "errorMessage": errors.email_address.errorMessage,
           "id": "input-email_address",
+          "type": "email",
           "name": "email_address",
           "value": form.email_address.data,
           "attributes": {
             "autocomplete": "off",
+            "spellcheck": "false",
           },
         }) }}
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -24,24 +24,36 @@
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
 
-        {% with question = form.email_address.label,
-                name = "email_address",
-                error = errors.get('email_address', {}).get('message'),
-                hint = form.email_address.hint,
-                value = form.email_address.data,
-                autocomplete = "off"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.email_address.label.text,
+          },
+          "hint": {
+            "text": form.email_address.hint,
+          },
+          "errorMessage": errors.email_address.errorMessage,
+          "id": "input-email_address",
+          "name": "email_address",
+          "value": form.email_address.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
-        {% with question = form.password.label,
-                name = "password",
-                error = errors.get('password', {}).get('message'),
-                value = form.password.data,
-                type = "password"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.password.label.text,
+          },
+          "errorMessage": errors.password.errorMessage,
+          "id": "input-password",
+          "type": "password",
+          "name": "password",
+          "value": form.password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
+
 
         {%
           with

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -33,15 +33,21 @@
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
 
-        {% with question = form.email_address.label,
-                name = "email_address",
-                error = errors.get('email_address', {}).get('message'),
-                hint = form.email_address.hint,
-                value = form.email_address.data,
-                autocomplete = "off"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.email_address.label.text,
+          },
+          "hint": {
+            "text": form.email_address.hint,
+          },
+          "errorMessage": errors.email_address.errorMessage,
+          "id": "input-email_address",
+          "name": "email_address",
+          "value": form.email_address.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
         {{ govukButton({
           "text": "Send reset email"

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -42,10 +42,12 @@
           },
           "errorMessage": errors.email_address.errorMessage,
           "id": "input-email_address",
+          "type": "email",
           "name": "email_address",
           "value": form.email_address.data,
           "attributes": {
             "autocomplete": "off",
+            "spellcheck": "false",
           },
         }) }}
 

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -29,24 +29,36 @@
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
 
-        {% with question = form.password.label,
-                name = "password",
-                error = errors.get('password', {}).get('message'),
-                hint = form.password.hint,
-                value = form.password.data,
-                type = "password"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.password.label.text,
+          },
+          "hint": {
+            "text": form.password.hint,
+          },
+          "errorMessage": errors.password.errorMessage,
+          "id": "input-password",
+          "type": "password",
+          "name": "password",
+          "value": form.password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
-        {% with question = form.confirm_password.label,
-                name = "confirm_password",
-                error = errors.get('confirm_password', {}).get('message'),
-                value = form.confirm_password.data,
-                type = "password"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {{ govukInput({
+          "label": {
+            "text": form.confirm_password.label.text,
+          },
+          "errorMessage": errors.confirm_password.errorMessage,
+          "id": "input-confirm_password",
+          "type": "password",
+          "name": "confirm_password",
+          "value": form.confirm_password.data,
+          "attributes": {
+            "autocomplete": "off",
+          },
+        }) }}
 
         {{ govukButton({
           "text": "Reset password"

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -276,12 +276,14 @@ class TestResetPassword(BaseApplicationTest):
         assert res.status_code == 200
         assert "Reset password for email@email.com" in res.get_data(as_text=True)
 
-        # Reset form should not display the 'Old password' field
         document = html.fromstring(res.get_data(as_text=True))
-        form_labels = document.xpath('//main//form//label/text()')
+
+        # Reset form should not display the 'Old password' field
+        assert not document.xpath("//main//form//label[normalize-space()='Old password']")
 
         for label in ['New password', 'Confirm new password']:
-            assert label in form_labels
+            assert document.xpath(f"//main//form//label[normalize-space()='{label}']")
+
         assert self.data_api_client.update_user_password.called is False
 
     def test_password_should_not_be_empty(self):
@@ -494,10 +496,8 @@ class TestChangePassword(BaseApplicationTest):
 
         self.assert_breadcrumbs(response, [("Your account", redirect_url), ("Change your password", None)])
 
-        form_labels = document.xpath('//form//label/text()')
-
         for label in ['Old password', 'New password', 'Confirm new password']:
-            assert label in form_labels
+            assert document.xpath(f"//form//label[normalize-space()='{label}']")
 
         assert len(document.xpath('//a[text()="Return to your account"]')) == 1
         assert self.data_api_client.update_user_password.called is False


### PR DESCRIPTION
We should be able to use `govuk-frontend` input component. This
replaces `digitalmarketplace-frontend-toolkit` textbox component.

We still need to decide whether we still want to have bold and slightly
larger labels compared to govuk-frontend default.


## Before

<img width="957" alt="Screenshot 2019-11-18 at 18 41 12" src="https://user-images.githubusercontent.com/3441519/69079923-e97ac080-0a32-11ea-82ba-ad001755c895.png">

## After

![image](https://user-images.githubusercontent.com/503614/69360113-e295bd00-0c81-11ea-9361-05e683c5dca6.png)

Ticket: https://trello.com/c/aSN47QjR