### PR TITLE
Simplify layout of create buyer user invalid domain error text

### DIFF
--- a/app/templates/auth/create-user-error.html
+++ b/app/templates/auth/create-user-error.html
@@ -17,20 +17,18 @@
         <p class="govuk-body">
           The email you used doesn't belong to a recognised public sector domain.
         </p>
-        <div class="explanation-list">
-          <p class="govuk-body-l">
-            <a class="govuk-link" href="{{ url_for('external.create_buyer_account') }}">Create an account using a different email address</a> or email
-            <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
-          </p>
-          <ul class="govuk-list">
-            <li>
-              you think your domain should be recognised
-            </li>
-            <li>
-              you still can't create an account
-            </li>
-          </ul>
-        </div>
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ url_for('external.create_buyer_account') }}">Create an account using a different email address</a> or email
+          <a class="govuk-link" href="mailto:{{ support_email_address }}">{{ support_email_address }}</a> if:
+        </p>
+        <ul class="govuk-list">
+          <li>
+            you think your domain should be recognised
+          </li>
+          <li>
+            you still can't create an account
+          </li>
+        </ul>
       </div>
     </div>
 


### PR DESCRIPTION
Removes explanation list and large style paragraph.

Counterpart of https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/249/commits/121a7e0f3020aaa2e380f8fc1bf2dcf1e7c00d47