### PR TITLE
Add autocomplete to forms and fields

### DIFF
--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -24,7 +24,7 @@
 
   <h1 class="govuk-heading-xl">Change your password</h1>
 
-  <form autocomplete="off" action="{{ url_for('.change_password') }}" method="POST">
+  <form action="{{ url_for('.change_password') }}" method="POST">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
@@ -39,7 +39,7 @@
           "name": "old_password",
           "value": form.old_password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "current-password",
           },
         }) }}
 
@@ -53,7 +53,7 @@
           "name": "password",
           "value": form.password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "new-password",
           },
         }) }}
 
@@ -68,7 +68,7 @@
           "name": "confirm_password",
           "value": form.confirm_password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "new-password",
           },
         }) }}
 

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -14,7 +14,7 @@
   <span class="govuk-caption-l">{{ email_address }}</span>
   <h1 class="govuk-heading-l">{{ headings[role] }}</h1>
 
-  <form autocomplete="off" action="{{ url_for('.submit_create_user', encoded_token=token) }}" method="POST" id="createUserForm">
+  <form action="{{ url_for('.submit_create_user', encoded_token=token) }}" method="POST" id="createUserForm">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
@@ -28,7 +28,8 @@
           "name": "name",
           "value": form.name.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "name",
+            "spellcheck": "false",
           },
         }) }}
 
@@ -46,7 +47,7 @@
             "name": "phone_number",
             "value": form.phone_number.data,
             "attributes": {
-              "autocomplete": "off",
+              "autocomplete": "tel",
             },
           }) }}
         {% endif %}
@@ -61,7 +62,7 @@
           "name": "password",
           "value": form.password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "new-password",
           },
         }) }}
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -19,7 +19,7 @@
 {% block mainContent %}
   <h1 class="govuk-heading-xl">Log in to the Digital Marketplace</h1>
 
-  <form autocomplete="off" action="{{ url_for('.process_login', next=next) }}" method="POST">
+  <form action="{{ url_for('.process_login', next=next) }}" method="POST">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
@@ -37,7 +37,7 @@
           "name": "email_address",
           "value": form.email_address.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "username",
             "spellcheck": "false",
           },
         }) }}
@@ -52,7 +52,7 @@
           "name": "password",
           "value": form.password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "current-password",
           },
         }) }}
 

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -28,7 +28,7 @@
     password. Password reset links are only valid for 24 hours.
   </p>
 
-  <form autocomplete="off" action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
+  <form action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
@@ -46,7 +46,7 @@
           "name": "email_address",
           "value": form.email_address.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "username",
             "spellcheck": "false",
           },
         }) }}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -24,7 +24,7 @@
     Reset password for {{ email_address }}
   </p>
 
-  <form autocomplete="off" action="{{ url_for('.update_password', token=token) }}" method="POST">
+  <form action="{{ url_for('.update_password', token=token) }}" method="POST">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}
@@ -42,7 +42,7 @@
           "name": "password",
           "value": form.password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "new-password",
           },
         }) }}
 
@@ -56,7 +56,7 @@
           "name": "confirm_password",
           "value": form.confirm_password.data,
           "attributes": {
-            "autocomplete": "off",
+            "autocomplete": "new-password",
           },
         }) }}
 

--- a/tests/main/views/test_reset_password.py
+++ b/tests/main/views/test_reset_password.py
@@ -503,6 +503,35 @@ class TestChangePassword(BaseApplicationTest):
         assert self.data_api_client.update_user_password.called is False
 
     @pytest.mark.parametrize(
+        "user_role",
+        ("buyer", "supplier", "admin")
+    )
+    def test_form_inputs_specify_input_purpose(self, user_role):
+        if user_role == "buyer":
+            self.login_as_buyer()
+        elif user_role == "admin":
+            self.login_as_admin()
+        elif user_role == "supplier":
+            self.login_as_supplier()
+
+        response = self.client.get("/user/change-password")
+        assert response.status_code == 200
+
+        doc = html.fromstring(response.get_data(as_text=True))
+        form = doc.cssselect("#content form")[0]
+
+        assert form.get("autocomplete") != "off"
+
+        assert form.inputs["old_password"].get("type") == "password"
+        assert form.inputs["old_password"].get("autocomplete") == "current-password"
+
+        assert form.inputs["password"].get("type") == "password"
+        assert form.inputs["password"].get("autocomplete") == "new-password"
+
+        assert form.inputs["confirm_password"].get("type") == "password"
+        assert form.inputs["confirm_password"].get("autocomplete") == "new-password"
+
+    @pytest.mark.parametrize(
         'user_role, redirect_url, user_email',
         [
             ('buyer', '/buyers', 'buyer@email.com'),


### PR DESCRIPTION
Ticket: https://trello.com/c/9Swa9RO1/167-3-remove-autocomplete-off-from-our-login-page

WCAG 2.1 requires that forms fields specify their input purpose [[1]].

[1]: https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html