### PR TITLE
Try Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+# Dependabot config
+# https://dependabot.com/docs/config-file/
+# Checks and updates dependencies in
+# `requirements.in` and `requirements.txt`
+
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "weekly"
+    allowed_updates:
+      - match:
+          dependency_type: "production"
+          update_type: "all"


### PR DESCRIPTION
I would like to try using [Dependabot](https://dependabot.com) with a frontend repo, as we have been having issues with PyUp recently. This PR is an experiment, I expect that it will either be superseded or reverted at a later date.

This PR adds a [Dependabot config file](https://dependabot.com/docs/config-file/) that I think should cause Dependabot to update requirements in `requirements.txt` weekly. Unfortunately the configuration for Dependabot doesn't seem to be as flexible as PyUp's. I can't see a way to specify filenames using the Dependabot config file format; there might be a way to do so in the GUI, I'm not sure.

On the plus side for Dependabot, we could use it to manage both Python and JavaScript dependencies. Also, Dependabot claims that its [Python features](https://dependabot.com/python/) include being able to manage Git sources (not sure how).