### PR TITLE
Fix govuk-frontend images path

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -31,7 +31,7 @@ $path: "/user/static/images/";
 
 // GOV.UK Design System (compatible with old toolkit/elements)
 $govuk-assets-path: '/user/static/';
-$govuk-images-path: '/user/static/images/govuk-frontend/';
+$govuk-images-path: '/user/static/images/';
 $govuk-fonts-path: '/user/static/fonts/';
 $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -242,7 +242,7 @@ gulp.task(
   copyFactory(
     'images from the GOVUK frontend',
     govukFrontendImageFolder,
-    staticFolder + '/images/govuk-frontend/'
+    path.join(staticFolder, 'images')
   )
 )
 


### PR DESCRIPTION
We wanted GOV.UK Frontend image assets to be in a separate folder in our
static assets directory structure; however, this doesn't fit with the
[page template for GOV.UK Frontend][1], which expects the favicon (and
other image assets) to be located in `/static/images`.

This commit changes the gulp task and Sass configuration to put GOV.UK
Frontend image assets in this location.

Related to https://trello.com/c/NjfXXwRH/1382-admin-frontend-has-no-favicon

[1]: https://github.com/alphagov/govuk-frontend/blob/v2.13.0/src/template.njk#L17