### PR TITLE
Cookie settings page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,5 +5,7 @@
   directives to concatenate multiple Javascript files into one.
 */
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
+//= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/digitalmarketplace-govuk-frontend.js
 
 GOVUKFrontend.initAll()
+DMGOVUKFrontend.initAll()

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -27,6 +27,7 @@ $govuk-compatibility-govukelements: true;
 @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all";
 
 // Overrides
+@import "overrides/_cookie-settings";
 @import "overrides/_notification-banner";
 @import "overrides/_govuk-label";
 

--- a/app/assets/scss/overrides/_cookie-settings.scss
+++ b/app/assets/scss/overrides/_cookie-settings.scss
@@ -1,0 +1,27 @@
+// Custom styles for digitalmarketplace-govuk-frontend CookieSettings component
+
+// Settings form and banner messages are not shown if Javascript is not enabled
+.dm-cookie-settings__form-wrapper,
+.dm-cookie-settings__warning {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+  }
+}
+
+.dm-cookie-settings__no-js {
+  .js-enabled & {
+    display: none;
+  }
+}
+
+.dm-cookie-settings__confirmation {
+  @include govuk-font(19);
+  display: none;
+}
+
+.dm-cookie-settings__error {
+  @include govuk-font(19);
+  display: none;
+}

--- a/app/assets/scss/overrides/_govuk-label.scss
+++ b/app/assets/scss/overrides/_govuk-label.scss
@@ -13,3 +13,8 @@
 
   margin-bottom: govuk-spacing(2);
 }
+
+// Cookie settings form labels use the govuk-frontend govukRadios component, so we can keep the original styling
+form#dm-cookie-settings .govuk-label {
+  @include govuk-font($size: 19);
+}

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,4 +3,4 @@ from flask import Blueprint
 main = Blueprint('main', __name__)
 
 from . import errors
-from .views import auth, reset_password, create_user, status, notifications
+from .views import auth, reset_password, create_user, status, notifications, cookie_settings

--- a/app/main/views/cookie_settings.py
+++ b/app/main/views/cookie_settings.py
@@ -1,0 +1,9 @@
+# coding: utf-8
+from .. import main
+from dmutils.flask import timed_render_template as render_template
+
+
+@main.route('/cookie-settings', methods=["GET"])
+def cookie_settings():
+    # Preferences saved client side as cookies, so no POST required
+    return render_template('cookies/cookie_settings.html')

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -11,6 +11,7 @@
 
 
 {# Import DM Components #}
+{% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
 {% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
@@ -25,6 +26,12 @@
 {% endblock %}
 
 {% block header %}
+  {% block cookieBanner %}
+    {{ dmCookieBanner({
+      'cookieSettingsUrl': url_for('main.cookie_settings'),
+      'cookieInfoUrl': url_for('external.cookies'),
+    }) }}
+  {% endblock %}
   {{ dmHeader({
     "role": current_user.role | default(None)
   }) }}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -7,11 +7,13 @@
 {% from "govuk-frontend/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk-frontend/components/input/macro.njk" import govukInput %}
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk-frontend/components/radios/macro.njk" import govukRadios %}
 
 
 {# Import DM Components #}
-{% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
-{% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
+{% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
+{% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
+{% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
 
 {% set assetPath = '/user/static' %}
 

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -16,6 +16,9 @@
   ]}) }}
 {% endblock %}
 
+{# Hide the Cookie banner on this page to avoid multiple forms for the same action #}
+{% block cookieBanner %}{% endblock %}
+
 {% block mainContent %}
 
   {{ dmAlert({

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -1,0 +1,133 @@
+{% extends "_base_page.html" %}
+
+{% block pageTitle %}
+  Change your cookie settings on Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {{ govukBreadcrumbs({"items": [
+    {
+      "text": "Digital Marketplace",
+      "href": url_for('external.index'),
+    },
+    {
+      "text": "Change your cookie settings",
+    },
+  ]}) }}
+{% endblock %}
+
+{% block mainContent %}
+
+  {{ dmAlert({
+    "type": "error",
+    "classes": "dm-cookie-settings__error",
+    "titleText": "There was a problem saving your settings",
+    "text": "Please select 'Yes' or 'No'.",
+    "attributes": [("id", "dm-cookie-settings-error")]
+  }) }}
+
+  {{ dmAlert({
+    "type": "success",
+    "classes": "dm-cookie-settings__confirmation",
+    "titleText": "Your cookie settings were saved",
+    "html": '<p class="govuk-body">You can change your preferences at any time on this page.</p><p class="govuk-body"><a href="/" class="govuk-link dm-cookie-settings__prev-page">Go back to the page you were looking at.</a></p>',
+    "attributes": [("id", "dm-cookie-settings-confirmation")]
+  }) }}
+
+  {{ dmAlert({
+    "type": "notice",
+    "classes": "dm-cookie-settings__warning",
+    "titleText": "Your cookie settings have not yet been saved",
+    "text": 'Digital Marketplace sets cookies when you visit our website. You can choose to change these settings to your own preferences. You need to save this page with your new choices.',
+    "attributes": [("id", "dm-cookie-settings-warning")]
+  }) }}
+
+  <h1 class="govuk-heading-xl">Change your cookie settings</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-body">
+        Cookies are files saved on your phone, tablet or computer when you visit a website.
+      </p>
+
+      <p class="govuk-body">
+        We use cookies to make the Digital Marketplace work and collect information about how you use our service.
+      </p>
+
+      <h2 class="govuk-heading-l">Cookie settings</h2>
+      <div class="dm-cookie-settings__no-js">
+        <div class="govuk-govspeak">
+          <p>We use Javascript to set most of our cookies.
+            Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
+          <ul class="govuk-list">
+            <li>reloading the page</li>
+            <li>turning on Javascript in your browser</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="dm-cookie-settings__form-wrapper">
+        <p class="govuk-body">We use 2 types of cookies.</p>
+
+        <h3 class="govuk-heading-m">Essential cookies</h3>
+        <p class="govuk-body">These essential cookies do things like to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>store sessions on your computer to help keep your information secure while you use the service</li>
+          <li>test whether your browser is able to accept session cookies, allowing us to show a useful error message if you try to log in without cookies enabled</li>
+          <li>remember the notifications you&rsquo;ve seen so we do not show them to you again</li>
+        </ul>
+
+
+          <h3 class="govuk-heading-m">Cookies that measure website use (optional)</h3>
+
+          <p class="govuk-body">
+            With your permission, we use Google Analytics to collect data about how you use the Digital Marketplace.
+            This information helps us to improve our service.
+          </p>
+          <p class="govuk-body">
+            Google is not allowed to use or share our analytics data with anyone.
+          </p>
+          <p class="govuk-body">
+            Google Analytics stores anonymised information about:
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>how you got to Digital Marketplace</li>
+            <li>the pages you visit on Digital Marketplace and government digital services, and how long you spend on each page</li>
+            <li>what you click on while you&rsquo;re using the service</li>
+          </ul>
+
+        <form id="dm-cookie-settings" data-module="dm-cookie-settings">
+          {{ govukRadios({
+            "name": "cookies-analytics",
+            "idPrefix": "cookie-settings",
+            "classes": "govuk-radios--inline",
+            "fieldset": {
+              "legend": {
+                "text": "Do you want to accept analytics cookies?",
+                "isPageHeading": false,
+                "classes": "govuk-fieldset__legend--m"
+              }
+            },
+            "items": [
+              {
+                "text": "Yes",
+                "value": "On"
+              },
+              {
+                "text": "No",
+                "value": "Off"
+              }
+            ]
+          }) }}
+
+          {{ govukButton({
+            "text": "Save cookie settings",
+          }) }}
+        </form>
+        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('external.cookies') }}">Find out more about cookies on Digital Marketplace</a></p>
+      </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -60,14 +60,12 @@
 
       <h2 class="govuk-heading-l">Cookie settings</h2>
       <div class="dm-cookie-settings__no-js">
-        <div class="govuk-govspeak">
-          <p>We use Javascript to set most of our cookies.
-            Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
-          <ul class="govuk-list">
-            <li>reloading the page</li>
-            <li>turning on Javascript in your browser</li>
-          </ul>
-        </div>
+        <p class="govuk-body">We use Javascript to set most of our cookies.
+          Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
+        <ul class="govuk-list">
+          <li>reloading the page</li>
+          <li>turning on Javascript in your browser</li>
+        </ul>
       </div>
 
       <div class="dm-cookie-settings__form-wrapper">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.4.1.tgz",
-      "integrity": "sha512-SecGO1BzepmOg9z13n5ZHoRIyw1FwrhntI2y5gum3hRFkKf38MwsRHNcq0MzR8HsyIc3UsIGj2pjehJqG7rdUA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.0.tgz",
+      "integrity": "sha512-JuThzUkpgeIRDFfdLnljqZcuz1Ywkzk5lsKdlsrRe20Dg0j8rEuvWhfPJU5rBtcnnyBfoLdILeOXKt55to2lsg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.4.1",
+    "digitalmarketplace-govuk-frontend": "^0.6.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ Flask>=1.0.4,<1.1.0
 Flask-Login>=0.4.1,<0.5.0
 Flask-WTF>=0.14.2,<0.15.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.0#egg=digitalmarketplace-utils
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cryptography==2.3.1
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.0#egg=digitalmarketplace-utils
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2

--- a/tests/main/views/test_cookie_settings.py
+++ b/tests/main/views/test_cookie_settings.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+from lxml import html
+
+from ...helpers import BaseApplicationTest
+
+
+class TestCookieSettings(BaseApplicationTest):
+    def test_cookie_settings_page(self):
+        res = self.client.get('/user/cookie-settings')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+        assert len(document.xpath('//h1[contains(text(), "Change your cookie settings")]')) == 1
+        assert len(document.xpath("//form//input[@name='cookies-analytics']")) == 2
+        assert len(document.xpath('//form//button[contains(text(), "Save cookie settings")]')) == 1
+
+        # Alert banners - visibility determined by cookies/JS
+        alerts = document.xpath('//div[@data-module="dm-alert"]//h2')
+        assert [alert.text_content().strip() for alert in alerts] == [
+            "There was a problem saving your settings",
+            "Your cookie settings were saved",
+            "Your cookie settings have not yet been saved"
+        ]
+
+        # 'Go back' link should default to the home page
+        assert document.xpath("//a[@class='govuk-link dm-cookie-settings__prev-page']")[0].get('href').strip() == '/'


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-cookie-settings-page

Adds new page for a user to set their cookie preferences, via the client side. 

Test coverage here: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/733

Pulls in https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/63 

![cookie-settings-page-feb-20202](https://user-images.githubusercontent.com/3492540/74043569-88271580-49c1-11ea-963f-55436a3a12fe.png)

