### PR TITLE
Update digitalmarketplace-govuk-frontend from 0.6.0 to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2535,9 +2535,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.0.tgz",
-      "integrity": "sha512-JuThzUkpgeIRDFfdLnljqZcuz1Ywkzk5lsKdlsrRe20Dg0j8rEuvWhfPJU5rBtcnnyBfoLdILeOXKt55to2lsg=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.1.tgz",
+      "integrity": "sha512-g2Cv99ZwN3inHebNnwkpzLKak7p2jBMmeC8xe9dulY9gHqcIb/G3G9uw/IZ4wLHmicZlCGxBjxo7DDrRQviouw=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.6.0",
+    "digitalmarketplace-govuk-frontend": "^0.6.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Ticket: https://trello.com/c/0PYrZ8Yy/323-cookie-settings-form-defaults-to-no-even-if-preference-set-to-yes