### PR TITLE
Update Analytics tracking ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2535,9 +2535,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.1.tgz",
-      "integrity": "sha512-g2Cv99ZwN3inHebNnwkpzLKak7p2jBMmeC8xe9dulY9gHqcIb/G3G9uw/IZ4wLHmicZlCGxBjxo7DDrRQviouw=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.2.tgz",
+      "integrity": "sha512-ic23jm3Cq/hq1tm2Io46JS6q94Ah4XdQxv5Vu5NuBpjsFTQNje2ji3tlnuVi0FI14e8NWztw/cYz53N7CG9iEQ=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.6.1",
+    "digitalmarketplace-govuk-frontend": "^0.6.2",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",


### PR DESCRIPTION
[No ticket]

Pulls in the fix for the Analytics tracking ID: https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/71