### PR TITLE
Pull in analytics initialisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2535,9 +2535,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.2.tgz",
-      "integrity": "sha512-ic23jm3Cq/hq1tm2Io46JS6q94Ah4XdQxv5Vu5NuBpjsFTQNje2ji3tlnuVi0FI14e8NWztw/cYz53N7CG9iEQ=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.3.tgz",
+      "integrity": "sha512-/HsZChuYoSV8uWfoVbqARTx7uGRnCTrRufygn7xRPJ2mTpRHYtGir/P7Iq1+pCrDjCbbkyW1zTVjAd10pQcarw=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.6.2",
+    "digitalmarketplace-govuk-frontend": "^0.6.3",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",


### PR DESCRIPTION
https://trello.com/c/feRizfhu/326-analytics-tracking-id-fix

Analytics was only being initialised when a user set or changed their preferences. Subsequent pageviews were not triggering an analytics request.

`all.js` now checks for a consent cookie, and initialises analytics if consent has been given.