### PR TITLE
Spike: using Redis for session storage [DO NOT MERGE]

### DIFF
--- a/app/main/views/reset_password.py
+++ b/app/main/views/reset_password.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask import current_app, flash, redirect, url_for, Markup, abort
+from flask import current_app, flash, redirect, url_for, Markup, abort, session
 from flask_login import current_user, login_required
 
 from dmutils.email import DMNotifyClient, generate_token, decode_password_reset_token, EmailError
@@ -205,6 +205,8 @@ def update_password(token):
 @main.route('/change-password', methods=["GET", "POST"])
 @login_required
 def change_password():
+    current_app.logger.debug("REDIS SESSION INFO")
+    current_app.logger.debug(session)
     form = PasswordChangeForm()
     dashboard_url = get_user_dashboard_url(current_user)
 

--- a/app/main/views/status.py
+++ b/app/main/views/status.py
@@ -1,8 +1,10 @@
-from flask import request
+from flask import request, current_app
+import pickle
 
 from .. import main
 from ... import data_api_client
 from dmutils.status import get_app_status
+from dmutils.flask import timed_render_template as render_template
 
 
 @main.route('/_status')
@@ -10,3 +12,30 @@ def status():
     return get_app_status(data_api_client=data_api_client,
                           search_api_client=None,
                           ignore_dependencies='ignore-dependencies' in request.args)
+
+
+@main.route('/_status/redis')
+def redis_console():
+    r = current_app.config['SESSION_REDIS']
+    session_cookie = request.cookies.get('dm_session')
+    current_session_id = 'session:{}'.format(session_cookie)
+
+    session_list = r.keys()
+    sessions = {id_: pickle.loads(r.get(id_)) for id_ in session_list}
+
+    expected_session_keys = [
+        '_permanent',
+        '_fresh'
+    ]
+    other_session_keys = [
+        'user_id',
+        'csrf_token'
+    ]
+
+    return render_template(
+        "redis_status.html",
+        current_session_id=current_session_id,
+        sessions=sessions,
+        expected_session_keys=expected_session_keys,
+        other_session_keys=other_session_keys
+    )

--- a/app/templates/redis_status.html
+++ b/app/templates/redis_status.html
@@ -1,0 +1,32 @@
+{% extends "_base_page.html" %}
+
+{% block mainContent %}
+<h1 class="govuk-heading-l">Redis status</h1>
+
+<p class="govuk-body">Current user session ID: {{ current_session_id }}</p>
+
+<h3 class="govuk-heading-m">Sessions</h3>
+<table class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">ID</th>
+          {% for k in expected_session_keys + other_session_keys %}
+            <th scope="col" class="govuk-table__header">{{ k }}</th>
+          {% endfor %}
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+{% for k, v in sessions.items() %}
+    <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ k.decode() }}</td>
+        {% for k in expected_session_keys %}
+            <td class="govuk-table__cell">{{ v[k] }}</td>
+        {% endfor %}
+        {% for k in other_session_keys %}
+            <td class="govuk-table__cell">{{ v.get(k) }}</td>
+        {% endfor %}
+    </tr>
+{% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/application.py
+++ b/application.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python
 
 import os
+import redis
 from app import create_app
+from flask_session import Session
 from dmutils import init_manager
 
 application = create_app(os.getenv('DM_ENVIRONMENT') or 'development')
+
+application.config.from_object(__name__)
+application.config['SESSION_REDIS'] = redis.from_url('redis://127.0.0.1:6379')
+sess = Session()
+sess.init_app(application)
+
 manager = init_manager(application, 5007)
 
 if __name__ == '__main__':

--- a/config.py
+++ b/config.py
@@ -12,10 +12,11 @@ class Config(object):
         os.path.abspath(os.path.dirname(__file__))
     )
     SESSION_COOKIE_NAME = 'dm_session'
-    SESSION_COOKIE_PATH = '/'
+    # SESSION_COOKIE_PATH = '/'
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_SAMESITE = "Lax"
+    SESSION_TYPE = 'redis'
 
     PERMANENT_SESSION_LIFETIME = 3600  # 1 hour
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@
 # This file was locked against the following input files:
 #
 # sha256:5bf2d823e0e26d736b2fe5ba2e1d4344aeceff3d25e1a763380213f291a507ba  requirements-dev.in
-# sha256:6ca64cbdc75fd3d1939bde320e8378c1762c552136d18400a1aba95f76e00c6a  requirements.txt
+# sha256:26329150cb71866361bd34c68d811371e3b2264f9034dcfc23b6ed82eaac5225  requirements.txt
 #
 argh==0.26.2              # via watchdog
 attrs==19.3.0             # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,8 @@
 Flask>=1.0.4,<1.1.0        # pyup: >=1.0.0,<1.1.0
 Flask-Login>=0.4.1,<0.5.0  # pyup: >=0.4.1,<0.5.0
 Flask-WTF>=0.14.3,<0.15.0  # pyup: >=0.14.3,<0.15.0
+Flask-Session==0.3.1
+redis==3.4.1
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@51.4.0#egg=digitalmarketplace-utils
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 # This file was locked against the following input files:
 #
-# sha256:824e78ef7e7a3fa40933a01d3c952a80256beba4ca4b5db08071643535fadac7  requirements.in
+# sha256:7f5937015860d96bd8e61a63e934fb2b46124611911644313b2595c9c9153eb0  requirements.in
 #
 asn1crypto==1.3.0         # via cryptography
 blinker==1.4              # via gds-metrics
@@ -27,6 +27,7 @@ docutils==0.15.2          # via botocore
 flask-gzip==0.2
 flask-login==0.4.1
 flask-script==2.0.6
+flask-session==0.3.1
 flask-wtf==0.14.3
 flask==1.0.4
 fleep==1.0.1
@@ -52,6 +53,7 @@ python-dateutil==2.8.1    # via botocore
 python-json-logger==0.1.11
 pytz==2019.3
 pyyaml==5.3
+redis==3.4.1
 requests==2.22.0          # via mailchimp3, notifications-python-client
 s3transfer==0.2.1         # via boto3
 six==1.13.0               # via cryptography, python-dateutil


### PR DESCRIPTION
https://trello.com/c/HQVLn3oi/335-fixing-the-logout-spike-1-run-flask-sessions-on-a-developer-laptop-max-3

This PR is purely for discussion purposes, and is not intended to be merged.

See ticket for full details and spike document.

- Installs `Flask-Session` plugin and Python `redis` wrapper library
- Hooks in a local Redis service at `localhost:6379` to the application config (in real life we'd do this in `dmutils.flask_init`, for use across apps)
- Example view of what Redis is storing (see below). An admin wouldn't need to see all this in order to expire a session, but it's useful for devs to see what's there (which is, all the normal stuff that's in the current session cookie!) and how to extract it from Redis.

![example-redis-status](https://user-images.githubusercontent.com/3492540/77921173-52066380-7297-11ea-9b1d-6551085b16b2.png)
