### PR TITLE
Remove jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7548,11 +7548,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
-    },
     "js-base64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "gulp-sass": "^4.0.2",
     "gulp-shell": "^0.7.1",
     "gulp-sourcemaps": "^2.6.5",
-    "gulp-uglify": "^3.0.2",
-    "jquery": "3.4.1"
+    "gulp-uglify": "^3.0.2"
   },
   "scripts": {
     "frontend-build:development": "gulp build:development",


### PR DESCRIPTION
https://trello.com/c/JNW4K4vr/1618-vulnerability-fix-tracking

The dependency was actually removed in https://github.com/alphagov/digitalmarketplace-user-frontend/pull/204, but not from `package.json`.

This supersedes the Snykbot PR https://github.com/alphagov/digitalmarketplace-user-frontend/pull/251.