### PR TITLE
use npm install step in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ freeze-requirements: virtualenv requirements-dev requirements.in requirements-de
 
 .PHONY: npm-install
 npm-install:
-	npm install
+	npm ci # If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock. (https://docs.npmjs.com/cli/ci.html)
 
 .PHONY: frontend-build
 frontend-build: npm-install

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ npm-install:
 	npm install
 
 .PHONY: frontend-build
-frontend-build:
+frontend-build: npm-install
 	npm run --silent frontend-build:${GULP_ENVIRONMENT}
 
 .PHONY: test


### PR DESCRIPTION
When running `dm-runner` on a clean machine I got the following error:
```
17:15:07            user-frontend | npm run --silent frontend-build:development
17:15:09            user-frontend | [17:15:09] Local modules not found in ~/git/digitalmarketplace-user-frontend
17:15:09            user-frontend | [17:15:09] Try running: npm install
```
This is because the Makefile previously did not call the `npm-install` step.

This PR changes the task to call `npm-install` also changes the command to be consistent with supplier-frontend by using `npm ci`
as per: https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/01b32bb756541b3aa2e52c949a0de4a351ddda64/Makefile#L40-L41
