### PR TITLE
add link to error summary box

### DIFF
--- a/app/assets/scss/overrides/_cookie-settings.scss
+++ b/app/assets/scss/overrides/_cookie-settings.scss
@@ -17,11 +17,9 @@
 }
 
 .dm-cookie-settings__confirmation {
-  @include govuk-font(19);
   display: none;
 }
 
 .dm-cookie-settings__error {
-  @include govuk-font(19);
   display: none;
 }

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -25,7 +25,11 @@
     "type": "error",
     "classes": "dm-cookie-settings__error",
     "titleText": "There was a problem saving your settings",
-    "text": "Please select 'Yes' or 'No'.",
+    "html": '<ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a href="#dm-cookie-settings">Please select \'Yes\' or \'No\'.</a>
+      </li>
+    </ul>',
     "attributes": [("id", "dm-cookie-settings-error")]
   }) }}
 

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -29,7 +29,7 @@
     },
     "errorList": [
       {
-        "text": "Please select 'Yes' or 'No'",
+        "text": "Select yes to accept analytics cookies",
         "href": "#dm-cookie-settings"
       }
     ]

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -21,16 +21,18 @@
 
 {% block mainContent %}
 
-  {{ dmAlert({
-    "type": "error",
-    "classes": "dm-cookie-settings__error",
+  {{ govukErrorSummary({
     "titleText": "There was a problem saving your settings",
-    "html": '<ul class="govuk-list govuk-error-summary__list">
-      <li>
-        <a href="#dm-cookie-settings">Please select \'Yes\' or \'No\'.</a>
-      </li>
-    </ul>',
-    "attributes": [("id", "dm-cookie-settings-error")]
+    "classes": "dm-cookie-settings__error",
+     "attributes": {
+      "id": "dm-cookie-settings-error"
+    },
+    "errorList": [
+      {
+        "text": "Please select 'Yes' or 'No'",
+        "href": "#dm-cookie-settings"
+      }
+    ]
   }) }}
 
   {{ dmAlert({

--- a/tests/main/views/test_cookie_settings.py
+++ b/tests/main/views/test_cookie_settings.py
@@ -17,10 +17,12 @@ class TestCookieSettings(BaseApplicationTest):
         # Alert banners - visibility determined by cookies/JS
         alerts = document.xpath('//div[@data-module="dm-alert"]//h2')
         assert [alert.text_content().strip() for alert in alerts] == [
-            "There was a problem saving your settings",
             "Your cookie settings were saved",
             "Your cookie settings have not yet been saved"
         ]
+
+        assert len(document.xpath('//*[@id="error-summary-title"][contains(text(),'
+                                  '"There was a problem saving your settings")]')) == 1
 
         # 'Go back' link should default to the home page
         assert document.xpath("//a[@class='govuk-link dm-cookie-settings__prev-page']")[0].get('href').strip() == '/'


### PR DESCRIPTION
Add [error summary component](https://design-system.service.gov.uk/components/error-summary/)  link.
This is part of: https://trello.com/c/btdB5xBK/98-missing-contextual-error-messaging-on-cookie-settings-page
![Screenshot 2020-05-21 at 15 06 28](https://user-images.githubusercontent.com/1764158/82567025-b0074700-9b74-11ea-9e7a-f73650d63c3e.png)
