### PR TITLE
bump digitalmarketplace-govuk-frontend version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,9 +2442,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.9.0.tgz",
-      "integrity": "sha512-xPtAMr3GxqwhSoxWTeEoiVenOXF9Fij1aKr81WgSjYYIp2mcRcnQAubXZSdm8UBur7uujfy8MtWxNycB4dh2hg=="
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.9.1.tgz",
+      "integrity": "sha512-nJz9n6h7go7rwUgYYHypWswZj3jqvWvlL9S1/lAyJDOoKEGsMlT+eoe4zMz/Wn3N/V3wbLYgOPxUvv5lj6lQcw=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.9.0",
+    "digitalmarketplace-govuk-frontend": "^0.9.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",


### PR DESCRIPTION
required for https://trello.com/c/btdB5xBK/98-missing-contextual-error-messaging-on-cookie-settings-page