### PR TITLE
Remove HTML5 validation from User FE forms

### DIFF
--- a/app/templates/auth/change-password.html
+++ b/app/templates/auth/change-password.html
@@ -24,7 +24,7 @@
 
   <h1 class="govuk-heading-xl">Change your password</h1>
 
-  <form action="{{ url_for('.change_password') }}" method="POST">
+  <form action="{{ url_for('.change_password') }}" method="POST" novalidate>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -19,7 +19,7 @@
 {% block mainContent %}
   <h1 class="govuk-heading-xl">Log in to the Digital Marketplace</h1>
 
-  <form action="{{ url_for('.process_login', next=next) }}" method="POST">
+  <form action="{{ url_for('.process_login', next=next) }}" method="POST" novalidate>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -28,7 +28,7 @@
     password. Password reset links are only valid for 24 hours.
   </p>
 
-  <form action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm">
+  <form action="{{ url_for('.request_password_reset') }}" method="POST" id="resetPasswordForm" novalidate>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -24,7 +24,7 @@
     Reset password for {{ email_address }}
   </p>
 
-  <form action="{{ url_for('.update_password', token=token) }}" method="POST">
+  <form action="{{ url_for('.update_password', token=token) }}" method="POST" novalidate>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         {{ form.hidden_tag() }}

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -105,7 +105,7 @@
             <li>what you click on while you&rsquo;re using the service</li>
           </ul>
 
-        <form id="dm-cookie-settings" data-module="dm-cookie-settings">
+        <form id="dm-cookie-settings" data-module="dm-cookie-settings" novalidate>
           {{ govukRadios({
             "name": "cookies-analytics",
             "idPrefix": "cookie-settings",

--- a/app/templates/notifications/user-research-consent.html
+++ b/app/templates/notifications/user-research-consent.html
@@ -51,7 +51,7 @@
         </p>
       {% endif %}
 
-      <form action="{{ url_for('main.user_research_consent') }}" method="POST">
+      <form action="{{ url_for('main.user_research_consent') }}" method="POST" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {%
           with


### PR DESCRIPTION
[no ticket]

Adds `novalidate` attribute to forms, as per the Design System guidance: https://design-system.service.gov.uk/patterns/validation/

