### PR TITLE
bump docker base version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:9.3.0
+FROM digitalmarketplace/base-frontend:9.4.0


### PR DESCRIPTION
bump docker image version to pick up changes from https://github.com/alphagov/digitalmarketplace-docker-base/pull/74