### PR TITLE
bump dockerfile version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:9.4.0
+FROM digitalmarketplace/base-frontend:9.5.0


### PR DESCRIPTION
bump docker version to pick up changes from https://github.com/alphagov/digitalmarketplace-docker-base/pull/75