### PR TITLE
Bump digitalmarketplace-govuk-frontend to 2.0.0-govuk-frontend-3-r2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2434,8 +2434,8 @@
       "dev": true
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "github:alphagov/digitalmarketplace-govuk-frontend#26080ba2f7da8bab743d810b9ae162e63cfe8a58",
-      "from": "github:alphagov/digitalmarketplace-govuk-frontend#26080ba"
+      "version": "github:alphagov/digitalmarketplace-govuk-frontend#c33045d95116df16e2ed82501945099da9292474",
+      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v2.0.0-govuk-frontend-3-r2"
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#26080ba",
+    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v2.0.0-govuk-frontend-3-r2",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",
     "gulp-include": "^2.4.1",


### PR DESCRIPTION
I created a new pre-release of digitalmarketplace-govuk-frontend with govuk-frontend v3, bringing in changes from release 1.0.1 of the main branch.

To do this I did the following:

    git checkout govuk-frontend-3

    # merge in changes from main branch, resolving conflicts in changelog
    git merge master

    # updated version number in package/package.json to 2.0.0-govuk-frontend-3-r2
    git commit package/package.json

    git push origin govuk-frontend-3

    npm run release-to-branch

    # tag the pre-release tree with a friendly name
    git tag pre-release-v2.0.0-govuk-frontend-3-r2
    git push --tags