### PR TITLE
Install digitalmarketplace-govuk-frontend and govuk-frontend separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 venv*
 node_modules
 npm-debug.log
+app/assets/scss/govuk
 app/static/*
 
 # Byte-compiled / optimized / DLL files

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,7 +4,7 @@
   Sprockets-style (https://github.com/sstephenson/sprockets)
   directives to concatenate multiple Javascript files into one.
 */
-//= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk/all.js
+//= require ../../../node_modules/govuk-frontend/govuk/all.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all.js
 
 GOVUKFrontend.initAll()

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -2,7 +2,7 @@
 $govuk-assets-path: '/user/static/';
 $govuk-images-path: '/user/static/images/';
 $govuk-fonts-path: '/user/static/fonts/';
-@import "node_modules/digitalmarketplace-govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/govuk/all";
 
 // Digital Marketplace Components
 @import "node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/all";

--- a/app/templates/cookies/cookie_settings.html
+++ b/app/templates/cookies/cookie_settings.html
@@ -40,7 +40,7 @@
     "classes": "dm-cookie-settings__confirmation",
     "titleText": "Your cookie settings were saved",
     "html": '<p class="govuk-body">You can change your preferences at any time on this page.</p><p class="govuk-body"><a href="/" class="govuk-link dm-cookie-settings__prev-page">Go back to the page you were looking at.</a></p>',
-    "attributes": [("id", "dm-cookie-settings-confirmation")]
+    "attributes": {"id": "dm-cookie-settings-confirmation"}
   }) }}
 
   {{ dmAlert({
@@ -48,7 +48,7 @@
     "classes": "dm-cookie-settings__warning",
     "titleText": "Your cookie settings have not yet been saved",
     "text": 'Digital Marketplace sets cookies when you visit our website. You can choose to change these settings to your own preferences. You need to save this page with your new choices.',
-    "attributes": [("id", "dm-cookie-settings-warning")]
+    "attributes": {"id": "dm-cookie-settings-warning"}
   }) }}
 
   <h1 class="govuk-heading-xl">Change your cookie settings</h1>

--- a/config.py
+++ b/config.py
@@ -60,12 +60,13 @@ class Config(object):
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
         digitalmarketplace_govuk_frontend = os.path.join(repo_root, "node_modules", "digitalmarketplace-govuk-frontend")
+        govuk_frontend = os.path.join(repo_root, "node_modules", "govuk-frontend")
 
         template_folders = [
             os.path.join(repo_root, 'app', 'templates'),
             os.path.join(digitalmarketplace_govuk_frontend),
+            os.path.join(govuk_frontend),
             os.path.join(digitalmarketplace_govuk_frontend, 'digitalmarketplace', 'templates'),
-            os.path.join(digitalmarketplace_govuk_frontend, 'govuk-frontend'),
         ]
         jinja_loader = jinja2.FileSystemLoader(template_folders)
         app.jinja_loader = jinja_loader

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ const path = require('path')
 let environment
 const repoRoot = path.join(__dirname)
 const npmRoot = path.join(repoRoot, 'node_modules')
-const govukFrontendRoot = path.join(npmRoot, 'digitalmarketplace-govuk-frontend', 'govuk')
+const govukFrontendRoot = path.join(npmRoot, 'govuk-frontend')
 const assetsFolder = path.join(repoRoot, 'app', 'assets')
 const staticFolder = path.join(repoRoot, 'app', 'static')
 const govukFrontendFontsFolder = path.join(govukFrontendRoot, 'assets', 'fonts')
@@ -32,7 +32,8 @@ const sassOptions = {
     outputStyle: 'expanded',
     lineNumbers: true,
     includePaths: [
-      assetsFolder + '/scss'
+      assetsFolder + '/scss',
+      govukFrontendRoot
     ],
     sourceComments: true,
     errLogToConsole: true
@@ -41,7 +42,8 @@ const sassOptions = {
     outputStyle: 'compressed',
     lineNumbers: true,
     includePaths: [
-      assetsFolder + '/scss'
+      assetsFolder + '/scss',
+      govukFrontendRoot
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4378,6 +4378,11 @@
         "sparkles": "^1.0.0"
       }
     },
+    "govuk-frontend": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.8.1.tgz",
+      "integrity": "sha512-1995FVvBSnwizhJ63BHFzd7T8uoOLUKO6NOOT0fAOYE7bdl8Ncf6yC5n3TqiwCJ4lPMc/dCGkN9Z4QRJchwoYQ=="
+    },
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2434,8 +2434,8 @@
       "dev": true
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "github:alphagov/digitalmarketplace-govuk-frontend#c33045d95116df16e2ed82501945099da9292474",
-      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v2.0.0-govuk-frontend-3-r2"
+      "version": "github:alphagov/digitalmarketplace-govuk-frontend#d6f09be154b0194cc792c33a3af239641bf3d520",
+      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r1"
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v2.0.0-govuk-frontend-3-r2",
+    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r1",
+    "govuk-frontend": "^3.8.0",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",
     "gulp-include": "^2.4.1",


### PR DESCRIPTION
https://trello.com/c/fhL8Zl8T/175-3-unbundle-govuk-frontend-from-digitalmarketplace-govuk-frontend

digitalmarketplace-govuk-frontend has been updated so that it is no longer bundled with govuk-frontend.

This PR addresses those changes.