### PR TITLE
Update error message on login

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -72,6 +72,7 @@ def process_login():
                 "auth/login.html",
                 form=form,
                 errors=errors,
+                error_summary_description_text=NO_ACCOUNT_MESSAGE,
                 next=next_url), 403
 
         user = User.from_json(user_json)

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -25,8 +25,8 @@ from ..helpers.login_helpers import redirect_logged_in_user
 from ... import data_api_client
 
 
-NO_ACCOUNT_MESSAGE = Markup("""Make sure you've entered the right email address and password. Accounts
-    are locked after 5 failed attempts. If you’ve forgotten your password you can reset it by clicking
+NO_ACCOUNT_MESSAGE = Markup("""Check you've entered the correct email address and password. Accounts
+    are locked after 5 failed attempts. If you’ve forgotten your password you can reset it by selecting
     ‘Forgotten password’.""")
 
 
@@ -60,11 +60,11 @@ def process_login():
                 extra={'email_hash': hash_string(form.email_address.data)})
             errors = govuk_errors({
                 "email_address": {
-                    "message": "Check your email address",
+                    "message": "Enter your email address",
                     "input_name": "email_address",
                 },
                 "password": {
-                    "message": "Check your password",
+                    "message": "Enter your password",
                     "input_name": "password",
                 },
             })

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -13,7 +13,10 @@ from flask import (
 from flask_login import logout_user, login_user
 
 from dmutils.flask import timed_render_template as render_template
-from dmutils.forms.helpers import get_errors_from_wtform
+from dmutils.forms.errors import (
+    get_errors_from_wtform,
+    govuk_errors,
+)
 from dmutils.user import User
 from dmutils.email.helpers import hash_string
 
@@ -56,11 +59,21 @@ def process_login():
             current_app.logger.info(
                 "login.fail: failed to log in {email_hash}",
                 extra={'email_hash': hash_string(form.email_address.data)})
+            errors = govuk_errors({
+                "email_address": {
+                    "message": "Check your email address",
+                    "input_name": "email_address",
+                },
+                "password": {
+                    "message": "Check your password",
+                    "input_name": "password",
+                },
+            })
             flash(NO_ACCOUNT_MESSAGE, "error")
             return render_template(
                 "auth/login.html",
                 form=form,
-                errors=get_errors_from_wtform(form),
+                errors=errors,
                 next=next_url), 403
 
         user = User.from_json(user_json)

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -25,7 +25,7 @@ from ..helpers.login_helpers import redirect_logged_in_user
 from ... import data_api_client
 
 
-NO_ACCOUNT_MESSAGE = Markup("""Check you've entered the correct email address and password. Accounts
+NO_ACCOUNT_MESSAGE = Markup("""Check you’ve entered the correct email address and password. Accounts
     are locked after 5 failed attempts. If you’ve forgotten your password you can reset it by selecting
     ‘Forgotten password’.""")
 

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -2,7 +2,6 @@
 from flask_login import current_user
 from flask import (
     current_app,
-    flash,
     get_flashed_messages,
     Markup,
     redirect,
@@ -69,7 +68,6 @@ def process_login():
                     "input_name": "password",
                 },
             })
-            flash(NO_ACCOUNT_MESSAGE, "error")
             return render_template(
                 "auth/login.html",
                 form=form,

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -68,6 +68,7 @@
     {% if errors %}
       {{ govukErrorSummary({
       "titleText": "There is a problem",
+      "descriptionText": error_summary_description_text,
       "errorList": errors.values(),
     }) }}
     {% endif %}

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -207,13 +207,21 @@ class TestLogin(BaseApplicationTest):
     def test_should_return_a_403_for_invalid_login(self):
         self.data_api_client.authenticate_user.return_value = None
 
-        res = self.client.post("/user/login", data={
+        response = self.client.post("/user/login", data={
             'email_address': 'valid@email.com',
             'password': '1234567890'
         })
         assert self.strip_all_whitespace(str(NO_ACCOUNT_MESSAGE)) \
-            in self.strip_all_whitespace(res.get_data(as_text=True))
-        assert res.status_code == 403
+            in self.strip_all_whitespace(response.get_data(as_text=True))
+
+        document = html.fromstring(response.get_data(as_text=True))
+        error_summary_links = document.cssselect('div.govuk-error-summary a')
+
+        assert len(error_summary_links) == 2
+        assert error_summary_links[0].attrib['href'] == '#input-email_address'
+        assert error_summary_links[1].attrib['href'] == '#input-password'
+
+        assert response.status_code == 403
 
     def test_should_be_validation_error_if_no_email_or_password(self):
         res = self.client.post("/user/login", data={})


### PR DESCRIPTION
https://trello.com/c/S54PAyW3/214-fix-error-messages-on-login-page-to-resolve-audit-issue

This PR improves the experience when a user enters the wrong credentials. Currently, we display a flash with an error message, which isn't the most helpful for e.g. screen readers.

Replace this with an error summary that instructs users to check their email and password and links to both fields.

New: 
![image](https://user-images.githubusercontent.com/15256121/92609007-f57b8b80-f2ad-11ea-86b6-819883f49d40.png)
