### PR TITLE
add instruction note

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,6 @@
+# Run `make freeze-requirements` to update requirements.txt
+# with package version changes made in requirements.in
+
 Flask>=1.0.4,<1.1.0
 Flask-Login>=0.5.0
 Flask-WTF>=0.14.3,<0.15.0


### PR DESCRIPTION
Noticed this whilst working on another story. This repo is missing the instruction note for requirements we include in other repos.