### PR TITLE
Remove pip-tools from requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,5 @@
 -c requirements.txt
 
-pip-tools>5.0.0
-
 cssselect
 flake8
 freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,10 +8,6 @@ argh==0.26.2
     # via watchdog
 attrs==19.3.0
     # via pytest
-click==7.0
-    # via
-    #   -c requirements.txt
-    #   pip-tools
 cssselect==1.1.0
     # via -r requirements-dev.in
 digitalmarketplace-test-utils==2.8.2
@@ -34,8 +30,6 @@ packaging==20.0
     # via pytest
 pathtools==0.1.2
     # via watchdog
-pip-tools==5.5.0
-    # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 py==1.10.0
@@ -69,6 +63,3 @@ watchdog==0.9.0
     # via -r requirements-dev.in
 wcwidth==0.1.8
     # via pytest
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip


### PR DESCRIPTION
https://trello.com/c/2dP0Dfmr/2357-fix-pip-tools-catch-22

As instructed, I have removed `pip-tools` and then updated the requirements files