### PR TITLE
Use updated Docker image base (v12 - `python:3.9-slim-bullseye`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:11.0.0
+FROM digitalmarketplace/base-frontend:12.0.0


### PR DESCRIPTION
https://trello.com/c/fK12wIdi/204-update-docker-images-to-use-newer-version-of-debian

Updated the docker file to use v12 of the base image which has updated the debian version from buster to bullseye
